### PR TITLE
fix(auth): scope session cookie to .clsplusplus.com for cross-subdomain reads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,7 @@ CLS_GOOGLE_API_KEY=...
 # Frontend origin. Required in prod when the API host differs from the UI host
 # (api.clsplusplus.com vs www.clsplusplus.com). Leave unset for same-origin dev.
 # CLS_FRONTEND_URL=https://www.clsplusplus.com
+
+# Session cookie Domain attribute. Required in prod so the cookie set by
+# api.clsplusplus.com is also sent on www.clsplusplus.com. Leave unset for dev.
+# CLS_COOKIE_DOMAIN=.clsplusplus.com

--- a/render.yaml
+++ b/render.yaml
@@ -38,3 +38,5 @@ services:
         sync: false
       - key: CLS_FRONTEND_URL
         sync: false
+      - key: CLS_COOKIE_DOMAIN
+        sync: false

--- a/src/clsplusplus/api.py
+++ b/src/clsplusplus/api.py
@@ -959,6 +959,7 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
             samesite="lax",
             max_age=7 * 86400,  # 7 days
             path="/",
+            domain=settings.cookie_domain or None,
         )
         return response
 

--- a/src/clsplusplus/config.py
+++ b/src/clsplusplus/config.py
@@ -113,6 +113,10 @@ class Settings(BaseSettings):
     # Site
     site_base_url: str = "https://www.clsplusplus.com"  # CLS_SITE_BASE_URL
     cookie_secure: bool = True  # CLS_COOKIE_SECURE (False for local dev only)
+    # Cookie Domain attribute. Set to ".clsplusplus.com" in prod so the session
+    # cookie set by api.clsplusplus.com is also sent on www.clsplusplus.com.
+    # Leave empty for same-host dev (cookie stays host-only).
+    cookie_domain: str = ""  # CLS_COOKIE_DOMAIN
 
     # Razorpay billing (active payment gateway)
     razorpay_key_id: str = ""               # CLS_RAZORPAY_KEY_ID


### PR DESCRIPTION
## Description

After yesterday's GitHub/Google OAuth merge, users who complete the sign-in flow land on `www.clsplusplus.com/profile` but see only the background video — nothing else renders. Root cause: the session cookie is **host-only** to `api.clsplusplus.com`, so when the browser navigates to the `www.` host and the profile page hits the API through Vercel's proxy, no cookie is forwarded and the auth check fails silently.

This PR adds a `CLS_COOKIE_DOMAIN` setting (default: empty, preserving current host-only behavior for local dev). Production sets it to `.clsplusplus.com` so the cookie is scoped to the parent domain and sent on both `api.` and `www.`.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Why this wasn't caught earlier

The email-signup flow creates the session via `POST /v1/auth/register` which — on local/dev — runs same-origin with the UI, so the host-only cookie works. OAuth surfaces the issue because OAuth callbacks are always hit directly on the API host (Google/GitHub redirect the browser there), after which the user is redirected to the UI host.

## Deploy prerequisite

**Required env var on Render** (already declared in `render.yaml` as `sync: false`):

```
CLS_COOKIE_DOMAIN=.clsplusplus.com
```

Leading dot is intentional: it makes the cookie valid on `clsplusplus.com` and every subdomain. Modern browsers treat `.clsplusplus.com` and `clsplusplus.com` identically for this purpose, but the leading-dot form is the explicit and widely-compatible spelling.

## Related issue(s)

None filed. Noticed during post-merge production verification of #419.

## Checklist

- [x] My code follows the project style
- [x] Existing auth tests still pass (cookie-setting is unchanged behaviorally when `CLS_COOKIE_DOMAIN` is unset — same default as before)
- [x] `.env.example` and `render.yaml` updated

## Post-merge verification

1. Set `CLS_COOKIE_DOMAIN=.clsplusplus.com` on Render → wait for redeploy.
2. Incognito → `https://www.clsplusplus.com/signup` → **Continue with GitHub** → complete consent.
3. Should land on `https://www.clsplusplus.com/profile` with the profile page rendered (not just background video).
4. DevTools → Application → Cookies → `cls_session` should show `Domain: .clsplusplus.com`.
5. Repeat with **Continue with Google** and with email sign-in.

## Rollback

- Unset `CLS_COOKIE_DOMAIN` on Render → falls back to host-only cookie (pre-PR behavior, profile still broken post-OAuth but email flow works).
- Full revert: `git revert de1e1d1 && git push`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)