### PR TITLE
fix(auth): route OAuth callbacks through Vercel proxy so session cookie lands on www.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,18 +21,26 @@ CLS_GOOGLE_API_KEY=...
 # CLS_RAZORPAY_KEY_SECRET=...
 # CLS_RAZORPAY_WEBHOOK_SECRET=...
 
-# "Continue with GitHub" sign-in. Create an OAuth App at
-# https://github.com/settings/developers — set the Authorization callback URL to
-# https://www.clsplusplus.com/v1/auth/github/callback
+# OAuth sign-in. Register the callback URLs on the **frontend** host so the
+# browser-visible Set-Cookie lands there (and can have Domain=.clsplusplus.com).
+# Vercel's `/api/v1/*` rewrite forwards the callback server-side to this backend.
+#
+# Google:  https://console.cloud.google.com/apis/credentials
+#   Authorized redirect URI: https://www.clsplusplus.com/api/v1/auth/google/callback
+# GitHub:  https://github.com/settings/developers
+#   Authorization callback URL: https://www.clsplusplus.com/api/v1/auth/github/callback
+#
+# CLS_GOOGLE_CLIENT_ID=...
+# CLS_GOOGLE_CLIENT_SECRET=...
+# CLS_GOOGLE_REDIRECT_URI=https://www.clsplusplus.com/api/v1/auth/google/callback
 # CLS_GITHUB_CLIENT_ID=Iv1...
 # CLS_GITHUB_CLIENT_SECRET=...
-# Optional — override the computed callback URL (normally leave unset)
-# CLS_GITHUB_REDIRECT_URI=https://www.clsplusplus.com/v1/auth/github/callback
+# CLS_GITHUB_REDIRECT_URI=https://www.clsplusplus.com/api/v1/auth/github/callback
 
-# Frontend origin. Required in prod when the API host differs from the UI host
-# (api.clsplusplus.com vs www.clsplusplus.com). Leave unset for same-origin dev.
+# Frontend origin. Used for post-auth redirect target.
 # CLS_FRONTEND_URL=https://www.clsplusplus.com
 
-# Session cookie Domain attribute. Required in prod so the cookie set by
-# api.clsplusplus.com is also sent on www.clsplusplus.com. Leave unset for dev.
+# Session cookie Domain attribute. Valid only when the cookie is set on a host
+# inside clsplusplus.com (which happens when OAuth callbacks go through the
+# Vercel proxy — see CLS_*_REDIRECT_URI above). Leave unset for dev.
 # CLS_COOKIE_DOMAIN=.clsplusplus.com

--- a/render.yaml
+++ b/render.yaml
@@ -36,6 +36,8 @@ services:
         sync: false
       - key: CLS_GITHUB_REDIRECT_URI
         sync: false
+      - key: CLS_GOOGLE_REDIRECT_URI
+        sync: false
       - key: CLS_FRONTEND_URL
         sync: false
       - key: CLS_COOKIE_DOMAIN

--- a/src/clsplusplus/api.py
+++ b/src/clsplusplus/api.py
@@ -1251,16 +1251,25 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
             raise HTTPException(status_code=404, detail="User not found")
         return user
 
+    def _google_callback_url(request: Request) -> str:
+        if settings.google_redirect_uri:
+            return settings.google_redirect_uri
+        callback_url = str(request.base_url).rstrip("/") + "/v1/auth/google/callback"
+        if (
+            request.headers.get("x-forwarded-proto") == "https"
+            or "onrender.com" in callback_url
+            or "clsplusplus.com" in callback_url
+        ):
+            callback_url = callback_url.replace("http://", "https://", 1)
+        return callback_url
+
     @app.get("/v1/auth/google")
     async def google_auth_redirect(request: Request, redirect: str = "/dashboard.html"):
         """Redirect to Google OAuth consent screen."""
         from urllib.parse import urlencode
         if not settings.google_client_id:
             raise HTTPException(status_code=501, detail="Google OAuth not configured")
-        callback_url = str(request.base_url).rstrip("/") + "/v1/auth/google/callback"
-        # Force HTTPS when behind reverse proxy (Render, Cloudflare, etc.)
-        if request.headers.get("x-forwarded-proto") == "https" or "onrender.com" in callback_url:
-            callback_url = callback_url.replace("http://", "https://", 1)
+        callback_url = _google_callback_url(request)
         params = urlencode({
             "client_id": settings.google_client_id,
             "redirect_uri": callback_url,
@@ -1277,10 +1286,7 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
         """Handle Google OAuth callback — exchange code, create/login user, redirect."""
         if not code:
             raise HTTPException(status_code=400, detail="Missing authorization code")
-        callback_url = str(request.base_url).rstrip("/") + "/v1/auth/google/callback"
-        # Force HTTPS when behind reverse proxy (Render, Cloudflare, etc.)
-        if request.headers.get("x-forwarded-proto") == "https" or "onrender.com" in callback_url:
-            callback_url = callback_url.replace("http://", "https://", 1)
+        callback_url = _google_callback_url(request)
         try:
             user, token = await user_service.google_auth(code, callback_url)
         except ValueError as e:

--- a/src/clsplusplus/config.py
+++ b/src/clsplusplus/config.py
@@ -37,7 +37,10 @@ class Settings(BaseSettings):
     google_client_secret: str = ""        # CLS_GOOGLE_CLIENT_SECRET
     github_client_id: str = ""            # CLS_GITHUB_CLIENT_ID
     github_client_secret: str = ""        # CLS_GITHUB_CLIENT_SECRET
-    # Optional explicit redirect URI; if empty, computed from request.base_url
+    # Optional explicit redirect URIs; if empty, computed from request.base_url.
+    # Set these when the OAuth callback must go through a frontend proxy (e.g.
+    # Vercel rewrites) so Set-Cookie lands on the UI host, not the API host.
+    google_redirect_uri: str = ""         # CLS_GOOGLE_REDIRECT_URI
     github_redirect_uri: str = ""         # CLS_GITHUB_REDIRECT_URI
 
     # Frontend origin for post-auth redirects. Needed when the API host


### PR DESCRIPTION
## Problem

After yesterday's OAuth merge, Google sign-in completes on the Google side, GitHub sign-in completes on the GitHub side, but the user lands on `www.clsplusplus.com/profile` with only the background video — the profile page can't see the session.

### Root cause

OAuth providers redirect the **browser** directly to the registered `redirect_uri`. The backend currently computes that URI from its own `request.base_url`, which on Render resolves to `clsplusplus.onrender.com`. The Set-Cookie therefore lands on `clsplusplus.onrender.com`.

`clsplusplus.onrender.com` and `www.clsplusplus.com` are on **different registrable domains** (`onrender.com` vs `clsplusplus.com`). A cookie set on the former cannot carry a `Domain=.clsplusplus.com` attribute — browsers reject that as an invalid cross-domain cookie. So the session cookie is orphaned on `onrender.com` and the UI on `www.clsplusplus.com` never sees it.

This was caught by live-running the OAuth endpoints:

```
GET /api/v1/auth/google?redirect=/profile →
  redirect_uri=https%3A%2F%2Fclsplusplus.onrender.com%2Fv1%2Fauth%2Fgoogle%2Fcallback

GET /api/v1/auth/github?redirect=/profile →
  redirect_uri=https%3A%2F%2Fwww.api.clsplusplus.com%2Fv1%2Fauth%2Fgithub%2Fcallback
  (from a typo'd CLS_GITHUB_REDIRECT_URI currently set on Render — needs correcting too)
```

## Fix

Register the redirect URIs on the **frontend host**: `https://www.clsplusplus.com/api/v1/auth/{google,github}/callback`. Vercel's `/api/v1/*` rewrite forwards the callback request to this backend server-side. The browser sees the response (and `Set-Cookie`) as coming from `www.clsplusplus.com`, where `Domain=.clsplusplus.com` is valid.

### Code changes

- `config.py`: add `google_redirect_uri` setting (GitHub already had one).
- `api.py`: new `_google_callback_url()` helper mirroring `_github_callback_url()`. Both the start endpoint and the callback handler now use it. When `CLS_GOOGLE_REDIRECT_URI` is set, that literal value is sent to Google; otherwise falls back to the old `request.base_url`-computed value (dev-friendly default).
- `.env.example` + `render.yaml`: document and declare `CLS_GOOGLE_REDIRECT_URI`; rewrite the comments to reflect the Vercel-proxy pattern.

No behaviour change in local dev (`frontend_url` / `*_redirect_uri` unset → computed URL as before).

## Type of change

- [x] Bug fix (user-facing OAuth sign-in was effectively broken post-callback)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Deploy prerequisites

Two things the caller must do; the code change alone doesn't fix anything.

### 1. Update Render env vars

```
CLS_GOOGLE_REDIRECT_URI=https://www.clsplusplus.com/api/v1/auth/google/callback
CLS_GITHUB_REDIRECT_URI=https://www.clsplusplus.com/api/v1/auth/github/callback
```

(The current `CLS_GITHUB_REDIRECT_URI` value on Render is typo'd to `https://www.api.clsplusplus.com/...` — overwrite it.)

Keep the existing `CLS_FRONTEND_URL=https://www.clsplusplus.com` and `CLS_COOKIE_DOMAIN=.clsplusplus.com` — they are still required.

### 2. Update OAuth provider callback URLs

**Google Cloud Console** → https://console.cloud.google.com/apis/credentials → your OAuth 2.0 Client ID → **Authorized redirect URIs** — add:
```
https://www.clsplusplus.com/api/v1/auth/google/callback
```
(The existing `clsplusplus.onrender.com` one can be kept for now or removed.)

**GitHub OAuth App** → https://github.com/settings/developers → your app → **Authorization callback URL** — set to:
```
https://www.clsplusplus.com/api/v1/auth/github/callback
```
(GitHub allows only one callback URL, so this is a replacement.)

## Test plan

After merge + deploy + env var update + provider URL update, in a fresh incognito window:

- [ ] `https://www.clsplusplus.com/signup` → **Continue with Google** → Google consent → land on `https://www.clsplusplus.com/profile` **with the full profile page rendered** (not just video).
- [ ] DevTools → Application → Cookies → `https://www.clsplusplus.com` → `cls_session` present with `Domain=.clsplusplus.com`.
- [ ] `/signup` → **Continue with GitHub** → same outcome.
- [ ] `/login` → same outcome from both buttons (labels read "Sign in with …").
- [ ] Email signup continues to work (no changes to that path).

## Rollback

- Unset `CLS_GOOGLE_REDIRECT_URI` and `CLS_GITHUB_REDIRECT_URI` on Render → the backend falls back to the old computed URLs. Revert the OAuth provider callback URLs to match the old Render host. OAuth will sign-in again but the cookie issue returns.
- Full revert: `git revert 979f478 && git push origin main`. Render redeploys in ~3 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)