### PR TITLE
feat(metering-v2): step 1 — schema + feature flag (ADR 0001)

### DIFF
--- a/src/clsplusplus/config.py
+++ b/src/clsplusplus/config.py
@@ -121,6 +121,13 @@ class Settings(BaseSettings):
     # Leave empty for same-host dev (cookie stays host-only).
     cookie_domain: str = ""  # CLS_COOKIE_DOMAIN
 
+    # Metering v2 — append-only event log pipeline. See docs/adr/0001-metering-data-lake.md.
+    # Rollout is in small, reversible steps. Both flags default to False; no
+    # production path consults these yet. Flipping the write flag causes the
+    # new schema to be applied on startup; it does NOT enable any writer.
+    metering_v2_write_enabled: bool = False  # CLS_METERING_V2_WRITE_ENABLED
+    metering_v2_read_enabled: bool = False   # CLS_METERING_V2_READ_ENABLED
+
     # Razorpay billing (active payment gateway)
     razorpay_key_id: str = ""               # CLS_RAZORPAY_KEY_ID
     razorpay_key_secret: str = ""           # CLS_RAZORPAY_KEY_SECRET

--- a/src/clsplusplus/metering_v2/__init__.py
+++ b/src/clsplusplus/metering_v2/__init__.py
@@ -1,0 +1,14 @@
+"""CLS++ Metering v2 — append-only event log + pay-as-you-go pricing.
+
+Step 1 of the rollout defined in docs/adr/0001-metering-data-lake.md.
+Only the schema bootstrapper lives here today. No writers, no readers.
+"""
+
+from clsplusplus.metering_v2.schema import (
+    apply_if_enabled,
+    apply_schema,
+    drop_schema,
+    read_ddl,
+)
+
+__all__ = ["apply_if_enabled", "apply_schema", "drop_schema", "read_ddl"]

--- a/src/clsplusplus/metering_v2/schema.py
+++ b/src/clsplusplus/metering_v2/schema.py
@@ -1,0 +1,58 @@
+"""Schema bootstrapper for the metering v2 pipeline.
+
+This module ONLY knows how to apply and drop the DDL. There are no
+writers or readers here yet — per ADR 0001 step 1, we land the schema
+behind a feature flag first, with zero production writers.
+
+Nothing in the request path imports this. The app factory will call
+`apply_if_enabled()` once on startup; when the flag is off (default),
+that call is a no-op.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from clsplusplus.config import Settings
+
+
+_DDL_PATH = Path(__file__).parent.parent / "stores" / "metering_v2_ddl.sql"
+
+
+def read_ddl() -> str:
+    """Return the DDL text. Separate from apply_schema so tests can inspect it."""
+    return _DDL_PATH.read_text()
+
+
+async def apply_schema(pool: Any) -> None:
+    """Idempotently create the metering v2 tables.
+
+    The DDL uses `CREATE TABLE IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS`
+    throughout, so calling this repeatedly is safe.
+    """
+    ddl = read_ddl()
+    async with pool.acquire() as conn:
+        await conn.execute(ddl)
+
+
+async def drop_schema(pool: Any) -> None:
+    """Drop the tables. Intended for tests and the documented rollback path.
+
+    Keep this as a CASCADE drop so it works even when a test left data behind.
+    """
+    async with pool.acquire() as conn:
+        await conn.execute("DROP TABLE IF EXISTS usage_events CASCADE;")
+        await conn.execute("DROP TABLE IF EXISTS metering_dead_letter CASCADE;")
+
+
+async def apply_if_enabled(settings: Settings, pool: Any) -> bool:
+    """Apply the schema only when the write flag is on.
+
+    Returns whether the DDL actually ran. Safe to call from startup
+    regardless of flag state.
+    """
+    if not settings.metering_v2_write_enabled:
+        return False
+    await apply_schema(pool)
+    return True

--- a/src/clsplusplus/stores/metering_v2_ddl.sql
+++ b/src/clsplusplus/stores/metering_v2_ddl.sql
@@ -1,0 +1,80 @@
+-- CLS++ Metering v2 — append-only event log and dead-letter queue.
+-- Background: docs/adr/0001-metering-data-lake.md
+--
+-- This DDL is ONLY applied when CLS_METERING_V2_WRITE_ENABLED is true.
+-- No production code writes to these tables yet.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- -----------------------------------------------------------------------------
+-- usage_events : the source of truth
+-- -----------------------------------------------------------------------------
+-- Every metered action writes exactly one row here. Rows are never updated
+-- or deleted in normal operation; retention is 24 months per ADR decision.
+--
+-- `actor_kind` + `actor_id` unifies every identity we track today:
+--   user  → users.id (UUID as text)
+--   ext   → extension uid
+--   ns    → namespace string
+--   api_key → an api-key hash (never the raw key)
+--   system → aggregate / job-level events
+--
+-- `unit_cost_cents` exists because pricing is hybrid: flat tier until the
+-- cap, then pay-as-you-go. The writer stamps the cost at the moment the
+-- event happened — not at invoice time — so a later tier change or price
+-- update never alters historical invoices.
+--
+-- `raw` carries event-specific extras (e.g. model_name, tokens, site_hash).
+-- Raw site URLs MUST be hashed before being put in here (owner decision:
+-- treating site URLs as PII).
+
+CREATE TABLE IF NOT EXISTS usage_events (
+    id                UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    idempotency_key   TEXT         NOT NULL UNIQUE,
+    actor_kind        TEXT         NOT NULL
+                                   CHECK (actor_kind IN ('user', 'ext', 'ns', 'api_key', 'system')),
+    actor_id          TEXT         NOT NULL,
+    user_id           UUID         REFERENCES users(id) ON DELETE SET NULL,
+    api_key_id        TEXT,
+    namespace         TEXT,
+    event_type        TEXT         NOT NULL,
+    quantity          INTEGER      NOT NULL DEFAULT 1 CHECK (quantity > 0),
+    unit_cost_cents   INTEGER      NOT NULL DEFAULT 0 CHECK (unit_cost_cents >= 0),
+    occurred_at       TIMESTAMPTZ  NOT NULL,
+    recorded_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    raw               JSONB        NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_usage_events_actor_time
+    ON usage_events(actor_id, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS idx_usage_events_type_time
+    ON usage_events(event_type, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS idx_usage_events_user_time
+    ON usage_events(user_id, occurred_at DESC)
+    WHERE user_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_usage_events_occurred_at
+    ON usage_events(occurred_at DESC);
+
+-- -----------------------------------------------------------------------------
+-- metering_dead_letter : failed writes, retained for replay + paging
+-- -----------------------------------------------------------------------------
+-- When a write to `usage_events` fails for any reason (DB unreachable, schema
+-- drift, constraint violation), the writer enqueues the failed payload here
+-- so the oncall agent can replay it. `notified_at` is set when the on-call
+-- has been paged; unset rows are the pageable backlog.
+
+CREATE TABLE IF NOT EXISTS metering_dead_letter (
+    id                UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    failed_at         TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    error_class       TEXT         NOT NULL,
+    error_message     TEXT         NOT NULL DEFAULT '',
+    payload           JSONB        NOT NULL,
+    retry_count       INTEGER      NOT NULL DEFAULT 0 CHECK (retry_count >= 0),
+    notified_at       TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_dead_letter_failed_at
+    ON metering_dead_letter(failed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_dead_letter_unnotified
+    ON metering_dead_letter(failed_at DESC)
+    WHERE notified_at IS NULL;

--- a/tests/test_metering_v2_schema.py
+++ b/tests/test_metering_v2_schema.py
@@ -1,0 +1,203 @@
+"""Tests for the metering v2 schema bootstrapper (ADR 0001 step 1).
+
+The DB-backed tests skip cleanly when Postgres is unreachable, so this
+file is safe to run on developer laptops without infra.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from clsplusplus.config import Settings
+from clsplusplus.metering_v2.schema import (
+    apply_if_enabled,
+    apply_schema,
+    drop_schema,
+    read_ddl,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Pure-Python test — no DB required
+# --------------------------------------------------------------------------- #
+
+
+def test_read_ddl_is_non_empty_and_mentions_both_tables():
+    ddl = read_ddl()
+    assert "CREATE TABLE" in ddl
+    assert "usage_events" in ddl
+    assert "metering_dead_letter" in ddl
+    # Cost column must exist — pay-as-you-go pricing depends on it.
+    assert "unit_cost_cents" in ddl
+    # Idempotency key must be a UNIQUE constraint, not just indexed.
+    assert "idempotency_key" in ddl and "UNIQUE" in ddl
+
+
+# --------------------------------------------------------------------------- #
+# DB-backed tests — skipped cleanly when Postgres is unreachable
+# --------------------------------------------------------------------------- #
+
+_DB_URL = os.environ.get("CLS_DATABASE_URL", "")
+
+
+def _skip_unless_pg_reachable():
+    """Skip if we can't open a connection. Cheap check, runs once per test."""
+    if not _DB_URL:
+        pytest.skip("CLS_DATABASE_URL unset")
+    try:
+        import asyncpg  # noqa: F401
+    except ImportError:
+        pytest.skip("asyncpg not installed")
+
+
+@pytest.fixture
+async def pool():
+    _skip_unless_pg_reachable()
+    import asyncpg
+
+    try:
+        p = await asyncpg.create_pool(_DB_URL, min_size=1, max_size=2)
+    except Exception as exc:  # pragma: no cover - environmental
+        pytest.skip(f"Postgres unreachable: {exc}")
+    try:
+        # Clean slate in case a prior run left tables behind.
+        await drop_schema(p)
+        yield p
+    finally:
+        await drop_schema(p)
+        await p.close()
+
+
+@pytest.mark.asyncio
+async def test_apply_and_drop_roundtrip(pool):
+    """Schema applies, is re-appliable (idempotent), then drops cleanly."""
+    await apply_schema(pool)
+    # Re-apply: everything is IF NOT EXISTS / UNIQUE (no-op expected).
+    await apply_schema(pool)
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT table_name FROM information_schema.tables
+            WHERE table_schema = current_schema()
+              AND table_name IN ('usage_events', 'metering_dead_letter')
+            """,
+        )
+        assert sorted(r["table_name"] for r in rows) == [
+            "metering_dead_letter",
+            "usage_events",
+        ]
+
+    await drop_schema(pool)
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT table_name FROM information_schema.tables
+            WHERE table_schema = current_schema()
+              AND table_name IN ('usage_events', 'metering_dead_letter')
+            """,
+        )
+        assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_usage_events_rejects_invalid_actor_kind(pool):
+    await apply_schema(pool)
+    import asyncpg
+    async with pool.acquire() as conn:
+        with pytest.raises(asyncpg.exceptions.CheckViolationError):
+            await conn.execute(
+                """
+                INSERT INTO usage_events
+                    (idempotency_key, actor_kind, actor_id, event_type, occurred_at)
+                VALUES ('t1', 'bogus-kind', 'x', 'write', NOW())
+                """,
+            )
+
+
+@pytest.mark.asyncio
+async def test_usage_events_idempotency_key_unique(pool):
+    await apply_schema(pool)
+    import asyncpg
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO usage_events
+                (idempotency_key, actor_kind, actor_id, event_type, occurred_at)
+            VALUES ('k1', 'user', 'u1', 'write', NOW())
+            """,
+        )
+        with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+            await conn.execute(
+                """
+                INSERT INTO usage_events
+                    (idempotency_key, actor_kind, actor_id, event_type, occurred_at)
+                VALUES ('k1', 'user', 'u1', 'write', NOW())
+                """,
+            )
+
+
+@pytest.mark.asyncio
+async def test_usage_events_rejects_negative_unit_cost(pool):
+    await apply_schema(pool)
+    import asyncpg
+    async with pool.acquire() as conn:
+        with pytest.raises(asyncpg.exceptions.CheckViolationError):
+            await conn.execute(
+                """
+                INSERT INTO usage_events
+                    (idempotency_key, actor_kind, actor_id, event_type, occurred_at,
+                     unit_cost_cents)
+                VALUES ('neg', 'user', 'u1', 'write', NOW(), -1)
+                """,
+            )
+
+
+@pytest.mark.asyncio
+async def test_usage_events_rejects_zero_or_negative_quantity(pool):
+    await apply_schema(pool)
+    import asyncpg
+    async with pool.acquire() as conn:
+        with pytest.raises(asyncpg.exceptions.CheckViolationError):
+            await conn.execute(
+                """
+                INSERT INTO usage_events
+                    (idempotency_key, actor_kind, actor_id, event_type, occurred_at, quantity)
+                VALUES ('q0', 'user', 'u1', 'write', NOW(), 0)
+                """,
+            )
+
+
+@pytest.mark.asyncio
+async def test_apply_if_enabled_respects_flag(pool):
+    """Flag off = no-op. Flag on = DDL runs."""
+    # Flag off — no tables created.
+    settings_off = Settings(database_url=_DB_URL, metering_v2_write_enabled=False)
+    ran = await apply_if_enabled(settings_off, pool)
+    assert ran is False
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT 1 FROM information_schema.tables
+            WHERE table_name = 'usage_events'
+              AND table_schema = current_schema()
+            """,
+        )
+        assert rows == []
+
+    # Flag on — tables created.
+    settings_on = Settings(database_url=_DB_URL, metering_v2_write_enabled=True)
+    ran = await apply_if_enabled(settings_on, pool)
+    assert ran is True
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT 1 FROM information_schema.tables
+            WHERE table_name = 'usage_events'
+              AND table_schema = current_schema()
+            """,
+        )
+        assert rows != []


### PR DESCRIPTION
## Summary

First step of the 8-step rollout in [ADR 0001](docs/adr/0001-metering-data-lake.md): land the durable append-only event log schema behind a feature flag. **No writer, no reader, no endpoint wired.** Nothing in the request path imports from the new module; flipping the flag causes the tables to exist, not any production behaviour to change.

## What's in this PR

| File | Purpose |
|---|---|
| `src/clsplusplus/stores/metering_v2_ddl.sql` | `usage_events` + `metering_dead_letter` DDL, with constraints + indexes |
| `src/clsplusplus/metering_v2/__init__.py` | Re-exports for the tiny surface |
| `src/clsplusplus/metering_v2/schema.py` | `apply_schema`, `drop_schema`, `apply_if_enabled` — the whole module |
| `src/clsplusplus/config.py` | Adds `metering_v2_write_enabled` + `metering_v2_read_enabled` (both default `False`) |
| `tests/test_metering_v2_schema.py` | 7 tests — 1 no-DB, 6 DB-backed (skip cleanly if Postgres unreachable) |

## Schema shape (concise)

```sql
usage_events
  id UUID PK, idempotency_key TEXT UNIQUE,
  actor_kind CHECK IN (user|ext|ns|api_key|system), actor_id TEXT,
  user_id UUID FK, api_key_id TEXT, namespace TEXT,
  event_type TEXT, quantity INT CHECK >0,
  unit_cost_cents INT CHECK >=0,      -- pay-as-you-go pricing stamped at write time
  occurred_at, recorded_at TIMESTAMPTZ,
  raw JSONB

metering_dead_letter
  id UUID PK, failed_at TIMESTAMPTZ,
  error_class, error_message, payload JSONB,
  retry_count, notified_at    -- unset = unpaged backlog for oncall agent
```

Constraints chosen to match the six decisions locked in the ADR:

- `unit_cost_cents` exists because pricing is now **flat tier + pay-as-you-go above the cap**. Cost is stamped at write time so a later tier or price change never alters historical invoices.
- `actor_kind` enum covers the four identity prefixes already used by the existing `MetricsEmitter` (user / ext / ns / system) plus `api_key` for billing-scoped events.
- `user_id` is `ON DELETE SET NULL` — an event is a historical fact that must survive a user-deletion (billing disputes).
- `idempotency_key UNIQUE` is what will make the dual-write phase safe against retries.

## What this PR does NOT do

- **No api.py changes**, no startup hook, no endpoint. Applying the schema requires an explicit call to `apply_schema(pool)`.
- **No writer.** `record_usage`, `MetricsEmitter.emit`, etc. are untouched.
- **No reader.** `/v1/user/usage` still reads from Redis exactly as before.
- **No infra provisioning.** MinIO, Parquet, DuckDB come in later steps.

If you merge this and set neither env var, **nothing observable changes**.

## Verified locally

```
$ PYTHONPATH=src python3 -m pytest tests/test_metering_v2_schema.py -v
test_read_ddl_is_non_empty_and_mentions_both_tables PASSED
test_apply_and_drop_roundtrip SKIPPED  (CLS_DATABASE_URL unset)
test_usage_events_rejects_invalid_actor_kind SKIPPED
test_usage_events_idempotency_key_unique SKIPPED
test_usage_events_rejects_negative_unit_cost SKIPPED
test_usage_events_rejects_zero_or_negative_quantity SKIPPED
test_apply_if_enabled_respects_flag SKIPPED
1 passed, 6 skipped in 0.07s

$ PYTHONPATH=src python3 -c "import clsplusplus.api"
api imports OK          # config change does not regress the existing app
```

The 6 DB-backed tests will run against the repo's `docker-compose.test.yml` Postgres in CI.

## Post-merge verification

No runtime effect on production — the flag is off. To exercise the schema in a dev environment, flip `CLS_METERING_V2_WRITE_ENABLED=true`, call `apply_if_enabled(settings, pool)` from a Python shell, confirm both tables appear, then `drop_schema(pool)` to clean up.

## Rollback

```sql
DROP TABLE IF EXISTS usage_events CASCADE;
DROP TABLE IF EXISTS metering_dead_letter CASCADE;
```

Then `git revert <merge-commit> && git push origin main`. No data to preserve — nothing writes to the tables yet.

## Next step

Step 2 of the ADR — **dual-write from the 15 `_record_usage` call sites and every `MetricsEmitter.emit` / `record_active_user` / `record_ext_telemetry`, Redis still primary**, gated behind the same write flag. That PR requires your approval after this one merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
