### PR TITLE
feat(metering-v2): step 3 — daily reconciler + admin endpoint (ADR 0001)

### DIFF
--- a/src/clsplusplus/api.py
+++ b/src/clsplusplus/api.py
@@ -124,34 +124,55 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
             title=app.title + " — API Documentation",
         )
 
-    # Metering v2 dead-letter notifier — runs only when the write flag is on.
-    # Polls metering_dead_letter every 60s, emails the oncall address, and
-    # marks rows notified. Flag-off startup is a no-op.
+    # Metering v2 background workers — run only when the write flag is on.
+    # The notifier (60s poll) pages oncall on dead-letter rows.
+    # The reconciler (24h poll) compares Redis counters to usage_events
+    # aggregates and enqueues any drift into dead_letter so the notifier
+    # picks it up. Flag-off startup is a no-op.
     _metering_notifier = None
+    _metering_reconciler = None
+
+    async def _metering_redis():
+        """Lazy Redis client for the reconciler. Returns None if unavailable."""
+        try:
+            import redis.asyncio as _redis
+            return _redis.from_url(settings.redis_url, decode_responses=True)
+        except Exception as exc:
+            logger.error("metering reconciler: redis init failed: %s: %s",
+                         type(exc).__name__, exc)
+            return None
 
     @app.on_event("startup")
     async def _metering_startup():
-        nonlocal _metering_notifier
+        nonlocal _metering_notifier, _metering_reconciler
         if not settings.metering_v2_write_enabled:
             return
         try:
-            from clsplusplus.metering_v2 import MeteringNotifier, apply_if_enabled
-            # Ensure the schema exists before the notifier tries to read it.
+            from clsplusplus.metering_v2 import (
+                MeteringNotifier, MeteringReconciler, apply_if_enabled,
+            )
+            # Ensure the schema exists before the workers touch it.
             pool = await user_service.store.get_pool()
             await apply_if_enabled(settings, pool)
             _metering_notifier = MeteringNotifier(
                 settings, _metering_pool, user_service.email,
             )
             _metering_notifier.start()
-            logger.info("metering v2: notifier started (poll=60s)")
+            _metering_reconciler = MeteringReconciler(
+                settings, _metering_pool, _metering_redis,
+            )
+            _metering_reconciler.start()
+            logger.info("metering v2: notifier (60s) + reconciler (24h) started")
         except Exception as exc:
-            logger.error("metering v2: notifier startup failed: %s: %s",
+            logger.error("metering v2: startup failed: %s: %s",
                          type(exc).__name__, exc)
 
     @app.on_event("shutdown")
     async def _metering_shutdown():
         if _metering_notifier is not None:
             await _metering_notifier.stop()
+        if _metering_reconciler is not None:
+            await _metering_reconciler.stop()
 
     # Explicit allowed origins — configurable via CLS_CORS_ORIGINS env var (comma-separated).
     # Chrome extension origins use the literal "chrome-extension://*" pattern which the
@@ -2083,6 +2104,31 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
         except Exception as e:
             logger.error("Admin waitlist promote error: %s: %s", type(e).__name__, e)
             raise HTTPException(status_code=500, detail="Promote failed")
+
+    @app.post("/admin/metering/reconcile")
+    async def admin_metering_reconcile(request: Request, period: Optional[str] = None):
+        """Run the metering reconciler on demand and return the summary.
+
+        Query param `period=YYYY-MM` selects the period (default: current).
+        Any drift findings are enqueued into metering_dead_letter as a side
+        effect, so the notifier will email on its next pump cycle.
+        """
+        _require_admin(request)
+        if not settings.metering_v2_write_enabled:
+            raise HTTPException(status_code=409,
+                                detail="Metering v2 write path is disabled")
+        if _metering_reconciler is None:
+            raise HTTPException(status_code=503,
+                                detail="Reconciler not initialised")
+        try:
+            result = await _metering_reconciler.reconcile_once(period)
+        except Exception as exc:
+            logger.error("admin reconcile: %s: %s", type(exc).__name__, exc)
+            raise HTTPException(status_code=500, detail="Reconciliation failed")
+        return {
+            **result.summary(),
+            "drift_findings": [f.to_payload() for f in result.findings[:50]],
+        }
 
     @app.post("/admin/tests/waitlist/run")
     async def admin_run_waitlist_tests(request: Request):

--- a/src/clsplusplus/metering_v2/__init__.py
+++ b/src/clsplusplus/metering_v2/__init__.py
@@ -2,12 +2,19 @@
 
 Rollout defined in docs/adr/0001-metering-data-lake.md. Steps landed:
 
-    step 1 — schema + feature flag (merged)
-    step 2 — dual-write + dead-letter notifier (this package)
+    step 1   — schema + feature flag (merged)
+    step 2   — dual-write + dead-letter notifier (merged)
+    step 2.5 — pay-as-you-go pricer (merged)
+    step 3   — daily reconciliation vs Redis (this package)
 """
 
 from clsplusplus.metering_v2.notifier import MeteringNotifier
 from clsplusplus.metering_v2.pricing import MeteringPricer, compute_unit_cost_cents
+from clsplusplus.metering_v2.reconciler import (
+    DriftFinding,
+    MeteringReconciler,
+    ReconciliationResult,
+)
 from clsplusplus.metering_v2.schema import (
     apply_if_enabled,
     apply_schema,
@@ -24,6 +31,9 @@ __all__ = [
     "MeteringWriter",
     "MeteringNotifier",
     "MeteringPricer",
+    "MeteringReconciler",
+    "DriftFinding",
+    "ReconciliationResult",
     "UsageEvent",
     "VALID_ACTOR_KINDS",
     "compute_unit_cost_cents",

--- a/src/clsplusplus/metering_v2/reconciler.py
+++ b/src/clsplusplus/metering_v2/reconciler.py
@@ -1,0 +1,293 @@
+"""Daily reconciliation of the durable log against the Redis counters
+(ADR 0001 step 3).
+
+Why this exists
+---------------
+Step 2 dual-writes every metered call to both Redis (`cls:ops:{api_key}:{period}`,
+fast counter) and Postgres (`usage_events`, durable log). They should
+agree to the last op. If they don't — a write dropped, a retry
+double-counted, a schema drift ate a field — billing is at risk.
+
+The reconciler compares the two views and pages on-call when drift
+crosses a configurable tolerance. Drift findings are written into the
+same `metering_dead_letter` table the writer uses, so the existing
+notifier emails them without needing a second transport.
+
+Because the ADR's back-dating window is 1 week, we MUST catch drift
+within 7 days. This runs daily and covers both the current and the
+prior period on every cycle, giving the on-call at most 48 h to react.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, asdict
+from datetime import datetime, timedelta, timezone
+from typing import Any, Awaitable, Callable, Optional
+
+from clsplusplus.config import Settings
+
+logger = logging.getLogger(__name__)
+
+
+# ADR 0001 §1: "alerts on > 0.1% drift".
+DEFAULT_DRIFT_PERCENT = 0.001
+# Ignore small absolute deltas — they're noise from the async write window.
+DEFAULT_MIN_ABS_DRIFT = 5
+# Daily loop interval.
+POLL_INTERVAL_SECONDS = 24 * 60 * 60
+
+
+PoolGetter = Callable[[], Awaitable[Any]]
+RedisGetter = Callable[[], Awaitable[Any]]
+
+
+def _hash_key(raw_key: str) -> str:
+    """Match MeteringWriter's api_key_id column: first 16 hex of SHA-256."""
+    return hashlib.sha256(raw_key.encode()).hexdigest()[:16]
+
+
+def _period_window(period: str) -> tuple[datetime, datetime]:
+    """Turn 'YYYY-MM' into [start, end) timestamps (UTC)."""
+    year, month = map(int, period.split("-"))
+    start = datetime(year, month, 1, tzinfo=timezone.utc)
+    if month == 12:
+        end = datetime(year + 1, 1, 1, tzinfo=timezone.utc)
+    else:
+        end = datetime(year, month + 1, 1, tzinfo=timezone.utc)
+    return start, end
+
+
+def _current_period() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m")
+
+
+def _prior_period() -> str:
+    now = datetime.now(timezone.utc)
+    year, month = now.year, now.month - 1
+    if month == 0:
+        year, month = year - 1, 12
+    return f"{year:04d}-{month:02d}"
+
+
+@dataclass
+class DriftFinding:
+    api_key_hash: str
+    period: str
+    redis_count: int
+    postgres_count: int
+    drift: int
+    drift_pct: float
+
+    def to_payload(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class ReconciliationResult:
+    period: str
+    redis_keys_seen: int
+    postgres_aggregates_seen: int
+    findings: list[DriftFinding]
+    elapsed_seconds: float
+
+    def summary(self) -> dict:
+        return {
+            "period": self.period,
+            "redis_keys_seen": self.redis_keys_seen,
+            "postgres_aggregates_seen": self.postgres_aggregates_seen,
+            "drift_count": len(self.findings),
+            "elapsed_seconds": round(self.elapsed_seconds, 3),
+        }
+
+
+class MeteringReconciler:
+    """Compares Redis ops counters to usage_events aggregates.
+
+    `reconcile_once(period)` runs a single comparison and returns findings.
+    `start()/stop()` runs the daily loop (current + prior period each cycle).
+    """
+
+    def __init__(
+        self,
+        settings: Settings,
+        pool_getter: PoolGetter,
+        redis_getter: RedisGetter,
+        drift_percent: float = DEFAULT_DRIFT_PERCENT,
+        min_abs_drift: int = DEFAULT_MIN_ABS_DRIFT,
+    ):
+        self.settings = settings
+        self._pool_getter = pool_getter
+        self._redis_getter = redis_getter
+        self._drift_pct = drift_percent
+        self._min_abs = min_abs_drift
+        self._task: Optional[asyncio.Task] = None
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.settings.metering_v2_write_enabled)
+
+    def start(self) -> None:
+        if self._task is not None and not self._task.done():
+            return
+        if not self.enabled:
+            return
+        self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        if self._task is None:
+            return
+        self._task.cancel()
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
+        self._task = None
+
+    async def reconcile_once(self, period: Optional[str] = None) -> ReconciliationResult:
+        """Compare the two views for one period. Writes drift to dead_letter.
+
+        Returns the findings for the caller to log / return from an
+        admin endpoint. The caller does NOT need to write dead_letter
+        rows — we've already done that.
+        """
+        t0 = asyncio.get_event_loop().time()
+        period = period or _current_period()
+
+        redis_counts = await self._scan_redis(period)
+        pg_counts = await self._aggregate_postgres(period)
+
+        findings = self._compare(period, redis_counts, pg_counts)
+        if findings:
+            await self._enqueue_findings(findings)
+
+        return ReconciliationResult(
+            period=period,
+            redis_keys_seen=len(redis_counts),
+            postgres_aggregates_seen=len(pg_counts),
+            findings=findings,
+            elapsed_seconds=asyncio.get_event_loop().time() - t0,
+        )
+
+    # --- internals ---------------------------------------------------
+
+    async def _run(self) -> None:
+        while True:
+            try:
+                await self.reconcile_once(_current_period())
+                await self.reconcile_once(_prior_period())
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.error("metering reconciler: %s: %s",
+                             type(exc).__name__, exc)
+            await asyncio.sleep(POLL_INTERVAL_SECONDS)
+
+    async def _scan_redis(self, period: str) -> dict[str, int]:
+        """Return {api_key_hash: ops_count} from Redis for the period.
+
+        Keys in Redis are `cls:ops:{RAW_api_key}:{period}` — we hash the
+        raw key on our side to match the writer's api_key_id scheme.
+        """
+        client = await self._redis_getter()
+        if client is None:
+            return {}
+        counts: dict[str, int] = {}
+        pattern = f"cls:ops:*:{period}"
+        try:
+            async for key in client.scan_iter(match=pattern, count=500):
+                # key = "cls:ops:{raw_api_key}:{period}"
+                # Strip prefix + suffix to get the raw key.
+                suffix = f":{period}"
+                if not key.endswith(suffix):
+                    continue
+                raw_key = key[len("cls:ops:"):-len(suffix)]
+                if not raw_key:
+                    continue
+                val = await client.get(key)
+                try:
+                    n = int(val) if val else 0
+                except (TypeError, ValueError):
+                    n = 0
+                if n > 0:
+                    counts[_hash_key(raw_key)] = counts.get(_hash_key(raw_key), 0) + n
+        except Exception as exc:
+            logger.error("reconciler: redis scan failed: %s: %s",
+                         type(exc).__name__, exc)
+        return counts
+
+    async def _aggregate_postgres(self, period: str) -> dict[str, int]:
+        """Return {api_key_id: sum(quantity)} from usage_events for the period."""
+        start, end = _period_window(period)
+        pool = await self._pool_getter()
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT api_key_id, SUM(quantity)::BIGINT AS total
+                FROM usage_events
+                WHERE api_key_id IS NOT NULL
+                  AND occurred_at >= $1
+                  AND occurred_at <  $2
+                GROUP BY api_key_id
+                """,
+                start, end,
+            )
+        return {r["api_key_id"]: int(r["total"]) for r in rows if r["api_key_id"]}
+
+    def _compare(
+        self,
+        period: str,
+        redis_counts: dict[str, int],
+        pg_counts: dict[str, int],
+    ) -> list[DriftFinding]:
+        findings: list[DriftFinding] = []
+        all_hashes = set(redis_counts) | set(pg_counts)
+        for h in all_hashes:
+            r = redis_counts.get(h, 0)
+            p = pg_counts.get(h, 0)
+            drift = abs(r - p)
+            if drift <= self._min_abs:
+                continue
+            denom = max(r, p, 1)
+            pct = drift / denom
+            if pct <= self._drift_pct:
+                continue
+            findings.append(DriftFinding(
+                api_key_hash=h,
+                period=period,
+                redis_count=r,
+                postgres_count=p,
+                drift=drift,
+                drift_pct=round(pct, 6),
+            ))
+        return findings
+
+    async def _enqueue_findings(self, findings: list[DriftFinding]) -> None:
+        """Write drift findings into metering_dead_letter. The existing
+        notifier picks them up on its next pump cycle."""
+        pool = await self._pool_getter()
+        async with pool.acquire() as conn:
+            for f in findings:
+                try:
+                    await conn.execute(
+                        """
+                        INSERT INTO metering_dead_letter
+                            (error_class, error_message, payload)
+                        VALUES ($1, $2, $3::jsonb)
+                        """,
+                        "ReconciliationDrift",
+                        (
+                            f"period={f.period} key={f.api_key_hash} "
+                            f"redis={f.redis_count} pg={f.postgres_count} "
+                            f"drift={f.drift} ({f.drift_pct * 100:.3f}%)"
+                        )[:500],
+                        json.dumps(f.to_payload()),
+                    )
+                except Exception as exc:
+                    logger.error(
+                        "reconciler: could not enqueue finding: %s: %s",
+                        type(exc).__name__, exc,
+                    )

--- a/tests/test_metering_v2_reconciler.py
+++ b/tests/test_metering_v2_reconciler.py
@@ -1,0 +1,287 @@
+"""Tests for MeteringReconciler (ADR 0001 step 3).
+
+Fakes for both Postgres and Redis so the whole file runs without infra.
+Covers the pure comparison logic, the scan loop, drift-to-dead-letter
+enqueue, tolerance thresholds, and the daily period helpers.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from clsplusplus.config import Settings
+from clsplusplus.metering_v2.reconciler import (
+    DriftFinding,
+    MeteringReconciler,
+    _current_period,
+    _hash_key,
+    _period_window,
+    _prior_period,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Fakes
+# --------------------------------------------------------------------------- #
+
+
+class FakeRedis:
+    """Minimal subset of redis.asyncio.Redis we use in reconciler."""
+
+    def __init__(self, keys: dict[str, int]):
+        # keys maps the full Redis key (e.g. "cls:ops:k1:2026-04") to count.
+        self.keys = dict(keys)
+
+    async def scan_iter(self, match: str, count: int = 500):
+        # Naive prefix / suffix match; enough for "cls:ops:*:YYYY-MM"
+        prefix, _, suffix = match.partition("*")
+        for k in list(self.keys.keys()):
+            if k.startswith(prefix) and k.endswith(suffix):
+                yield k
+
+    async def get(self, key: str):
+        v = self.keys.get(key)
+        return str(v) if v is not None else None
+
+
+class FakeConn:
+    def __init__(self, owner: "FakePool"):
+        self.owner = owner
+
+    async def fetch(self, sql: str, *args):
+        if "FROM usage_events" in sql:
+            return [
+                {"api_key_id": h, "total": n} for h, n in self.owner.pg_counts.items()
+            ]
+        return []
+
+    async def execute(self, sql: str, *args):
+        if "INTO metering_dead_letter" in sql:
+            self.owner.dead_letter.append(args)
+
+
+class _AcquireCtx:
+    def __init__(self, conn):
+        self.conn = conn
+
+    async def __aenter__(self):
+        return self.conn
+
+    async def __aexit__(self, *a):
+        return None
+
+
+class FakePool:
+    def __init__(self, pg_counts: dict[str, int]):
+        self.pg_counts = dict(pg_counts)
+        self.dead_letter: list = []
+
+    def acquire(self):
+        return _AcquireCtx(FakeConn(self))
+
+
+def _make_reconciler(
+    redis_keys: dict[str, int],
+    pg_counts: dict[str, int],
+    *,
+    drift_percent: float = 0.001,
+    min_abs_drift: int = 5,
+    enabled: bool = True,
+) -> tuple[MeteringReconciler, FakePool]:
+    pool = FakePool(pg_counts)
+    redis = FakeRedis(redis_keys)
+
+    async def pool_getter() -> Any:
+        return pool
+
+    async def redis_getter() -> Any:
+        return redis
+
+    settings = Settings(metering_v2_write_enabled=enabled)
+    rec = MeteringReconciler(
+        settings, pool_getter, redis_getter,
+        drift_percent=drift_percent,
+        min_abs_drift=min_abs_drift,
+    )
+    return rec, pool
+
+
+# --------------------------------------------------------------------------- #
+# Period helpers
+# --------------------------------------------------------------------------- #
+
+
+def test_period_window_january():
+    start, end = _period_window("2026-01")
+    assert start == datetime(2026, 1, 1, tzinfo=timezone.utc)
+    assert end == datetime(2026, 2, 1, tzinfo=timezone.utc)
+
+
+def test_period_window_december_rolls_year():
+    start, end = _period_window("2026-12")
+    assert start == datetime(2026, 12, 1, tzinfo=timezone.utc)
+    assert end == datetime(2027, 1, 1, tzinfo=timezone.utc)
+
+
+def test_prior_period_january_rolls_to_previous_year():
+    # This is a pure wall-clock function; sanity check against current month.
+    prior = _prior_period()
+    current = _current_period()
+    y1, m1 = map(int, prior.split("-"))
+    y2, m2 = map(int, current.split("-"))
+    if m2 == 1:
+        assert (y1, m1) == (y2 - 1, 12)
+    else:
+        assert (y1, m1) == (y2, m2 - 1)
+
+
+def test_hash_key_matches_writer_scheme():
+    # Writer uses sha256()[:16] — exact same scheme must match.
+    assert _hash_key("abcd") == _hash_key("abcd")
+    assert len(_hash_key("abcd")) == 16
+    assert _hash_key("a") != _hash_key("b")
+
+
+# --------------------------------------------------------------------------- #
+# Reconciliation logic
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_no_drift_when_both_views_agree():
+    h_k1 = _hash_key("k1")
+    redis = {"cls:ops:k1:2026-04": 10_000}
+    pg = {h_k1: 10_000}
+    rec, pool = _make_reconciler(redis, pg)
+    result = await rec.reconcile_once("2026-04")
+    assert result.findings == []
+    assert pool.dead_letter == []
+    assert result.redis_keys_seen == 1
+    assert result.postgres_aggregates_seen == 1
+
+
+@pytest.mark.asyncio
+async def test_small_absolute_drift_is_ignored():
+    """Abs drift under min_abs_drift is noise from async write lag."""
+    h_k1 = _hash_key("k1")
+    redis = {"cls:ops:k1:2026-04": 10_000}
+    pg = {h_k1: 10_003}  # drift=3 < min_abs=5 default
+    rec, pool = _make_reconciler(redis, pg)
+    result = await rec.reconcile_once("2026-04")
+    assert result.findings == []
+    assert pool.dead_letter == []
+
+
+@pytest.mark.asyncio
+async def test_small_percent_drift_is_ignored():
+    """Drift above min_abs but under the percent threshold is allowed."""
+    h_k1 = _hash_key("k1")
+    redis = {"cls:ops:k1:2026-04": 100_000}
+    pg = {h_k1: 100_050}  # 0.05% drift, under 0.1% threshold
+    rec, pool = _make_reconciler(redis, pg)
+    result = await rec.reconcile_once("2026-04")
+    assert result.findings == []
+
+
+@pytest.mark.asyncio
+async def test_large_drift_flags_finding():
+    h_k1 = _hash_key("k1")
+    redis = {"cls:ops:k1:2026-04": 10_000}
+    pg = {h_k1: 5_000}  # 50% drift, well over threshold
+    rec, pool = _make_reconciler(redis, pg)
+    result = await rec.reconcile_once("2026-04")
+    assert len(result.findings) == 1
+    f = result.findings[0]
+    assert f.api_key_hash == h_k1
+    assert f.redis_count == 10_000
+    assert f.postgres_count == 5_000
+    assert f.drift == 5_000
+    assert f.drift_pct == pytest.approx(0.5)
+    # Dead-letter row was enqueued.
+    assert len(pool.dead_letter) == 1
+    err_class, msg, _payload_json = pool.dead_letter[0]
+    assert err_class == "ReconciliationDrift"
+    assert "2026-04" in msg
+
+
+@pytest.mark.asyncio
+async def test_postgres_only_hash_flags_drift():
+    """Hash in PG but NOT in Redis means PG over-counted (or Redis was wiped)."""
+    rogue = _hash_key("ghost")
+    redis = {}
+    pg = {rogue: 1_000}
+    rec, pool = _make_reconciler(redis, pg)
+    result = await rec.reconcile_once("2026-04")
+    assert len(result.findings) == 1
+    f = result.findings[0]
+    assert f.redis_count == 0
+    assert f.postgres_count == 1_000
+
+
+@pytest.mark.asyncio
+async def test_redis_only_hash_flags_drift():
+    """Hash in Redis but NOT in PG means a write was dropped — THE money bug."""
+    redis = {"cls:ops:lost:2026-04": 5_000}
+    pg = {}
+    rec, pool = _make_reconciler(redis, pg)
+    result = await rec.reconcile_once("2026-04")
+    assert len(result.findings) == 1
+    f = result.findings[0]
+    assert f.api_key_hash == _hash_key("lost")
+    assert f.redis_count == 5_000
+    assert f.postgres_count == 0
+
+
+@pytest.mark.asyncio
+async def test_multiple_hashes_compared_independently():
+    h1, h2, h3 = _hash_key("k1"), _hash_key("k2"), _hash_key("k3")
+    redis = {
+        "cls:ops:k1:2026-04": 100,         # matches pg
+        "cls:ops:k2:2026-04": 200,         # drifts
+        "cls:ops:k3:2026-04": 1000,        # matches pg
+    }
+    pg = {h1: 100, h2: 500, h3: 1000}
+    rec, pool = _make_reconciler(redis, pg)
+    result = await rec.reconcile_once("2026-04")
+    drift_hashes = {f.api_key_hash for f in result.findings}
+    assert drift_hashes == {h2}
+
+
+@pytest.mark.asyncio
+async def test_scan_ignores_keys_from_other_periods():
+    """Pattern match is strict — don't pull prior-period keys into this window."""
+    redis = {
+        "cls:ops:k1:2026-04": 100,
+        "cls:ops:k1:2026-03": 999_999,  # wrong period
+    }
+    pg = {_hash_key("k1"): 100}
+    rec, pool = _make_reconciler(redis, pg)
+    result = await rec.reconcile_once("2026-04")
+    assert result.findings == []
+
+
+@pytest.mark.asyncio
+async def test_reconciler_disabled_still_returns_structure():
+    """Flag off shouldn't crash — reconcile_once is useful for manual runs."""
+    rec, pool = _make_reconciler({}, {}, enabled=False)
+    result = await rec.reconcile_once("2026-04")
+    assert result.findings == []
+    # enabled=False means the daily loop won't auto-start, but manual call works
+    assert rec.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_custom_thresholds():
+    """Caller can tighten or relax tolerance."""
+    h_k1 = _hash_key("k1")
+    redis = {"cls:ops:k1:2026-04": 1_000_000}
+    pg = {h_k1: 1_000_100}  # 0.01% drift, 100 absolute
+    # Default threshold: 0.1% + min_abs=5 — drift pct too small → no finding
+    rec_default, _ = _make_reconciler(redis, pg)
+    assert (await rec_default.reconcile_once("2026-04")).findings == []
+    # Tighten: 0.001% threshold — now it fires
+    rec_strict, _ = _make_reconciler(redis, pg, drift_percent=0.00001)
+    assert len(((await rec_strict.reconcile_once("2026-04")).findings)) == 1


### PR DESCRIPTION
## Summary

Step 3 of the rollout in [ADR 0001](docs/adr/0001-metering-data-lake.md). Closes the safety loop the ADR's **1-week back-dating window** depends on: every day, compare the fast Redis ops counters against the durable `usage_events` aggregates, and page on-call when drift crosses tolerance.

Without this, a dropped dual-write can silently accumulate for 30 days before anyone notices. With this, it's caught within 24 h and fixable within the 7-day back-dating window.

## What's in this PR

| File | Purpose |
|---|---|
| `src/clsplusplus/metering_v2/reconciler.py` | `MeteringReconciler` + `DriftFinding` + `ReconciliationResult` |
| `src/clsplusplus/metering_v2/__init__.py` | Re-exports |
| `src/clsplusplus/api.py` | Startup/shutdown hooks + `POST /admin/metering/reconcile` endpoint |
| `tests/test_metering_v2_reconciler.py` | 14 unit tests (all pass, zero infra required) |

## How it works

```
daily loop (24h):
  for period in [current, prior]:
    redis = scan("cls:ops:*:{period}")    → { hash(raw_key): count }
    pg    = SELECT api_key_id, SUM(quantity) FROM usage_events
                WHERE occurred_at IN [period_start, period_end)
            GROUP BY api_key_id
    for each hash in (redis ∪ pg):
        drift = |redis[hash] - pg[hash]|
        if drift > MIN_ABS (5) AND drift_pct > THRESHOLD (0.1%):
            enqueue ReconciliationDrift row into metering_dead_letter
```

The notifier already picks up dead-letter rows every 60s and emails `CLS_ONCALL_EMAIL`. We reuse that transport — no second paging path.

## Tolerance (configurable per-instance)

- `MIN_ABS_DRIFT = 5` — ignore small absolute deltas (noise from the async fire-and-forget write window between a Redis INCR and the Postgres INSERT).
- `DRIFT_PERCENT = 0.001` — ADR §1 ("> 0.1% drift"). Above this and the row pages.

## Admin endpoint

```
POST /admin/metering/reconcile?period=2026-04
```

Returns:

```json
{
  "period": "2026-04",
  "redis_keys_seen": 42,
  "postgres_aggregates_seen": 42,
  "drift_count": 2,
  "elapsed_seconds": 0.081,
  "drift_findings": [
    {
      "api_key_hash": "a1b2c3d4e5f60718",
      "period": "2026-04",
      "redis_count": 10000,
      "postgres_count": 5000,
      "drift": 5000,
      "drift_pct": 0.5
    }
  ]
}
```

Gated by the existing `_require_admin` guard. Returns 409 if the write flag is off, 503 if the reconciler hasn't initialised.

## Failure modes caught

| Symptom | Finding |
|---|---|
| Dead-letter queue empty, Redis counter high, PG low | **Money bug** — dual-write silently dropped |
| PG high, Redis low | Redis evicted early OR PG has rogue inserts (retry storm) |
| Sudden scan mismatch period-over-period | Schema drift or time-zone bug |

All of these produce `ReconciliationDrift` rows in `metering_dead_letter` which the notifier aggregates into the next 60s oncall email.

## What this PR does NOT do

- **Does not alter billing logic.** Detection only; remediation is manual (replay from dead_letter, reconcile counters by hand, or `UPDATE usage_events`).
- **Does not auto-fix drift.** That's deliberate — an automated repair that picks the wrong source of truth is the exact money-losing scenario we're guarding against.
- **Does not write to Parquet.** That's step 6 of the rollout.
- **Does not change the Redis key format.** Still the existing `cls:ops:{api_key}:{YYYY-MM}` pattern.

## Verification

```
$ PYTHONPATH=src python3 -m pytest tests/test_metering_v2_reconciler.py -v
14 passed in 0.23s

$ PYTHONPATH=src python3 -m pytest tests/test_metering_v2_*.py -q
30 passed, 7 skipped in 0.39s   # 7 DB-gated, skip without PG

$ PYTHONPATH=src python3 -c "import clsplusplus.api"
OK
```

## Post-merge flip-on

No extra config needed. Already-configured `CLS_METERING_V2_WRITE_ENABLED=true` starts the reconciler automatically on the next deploy. First reconciliation runs as soon as the app boots (for current period); subsequent runs are every 24 h for current + prior.

**On-demand smoke test after deploy**:
```
curl -X POST -H "Cookie: cls_session=<admin-session>" \
  "https://api.clsplusplus.com/admin/metering/reconcile?period=2026-04"
```

Expected: `drift_count: 0` assuming a quiet first day. If non-zero, investigate the findings — either the drift is real (step 2 has a bug) or the tolerance needs adjusting.

## Rollback

- `CLS_METERING_V2_WRITE_ENABLED=false` → reconciler never starts. Notifier also stops.
- `git revert <merge-commit> && git push origin main` → full removal. No data to migrate — findings that already landed in `metering_dead_letter` remain queryable.

## What's next

With steps 1–3 landed, we have durable writes + price stamping + daily drift detection. The ADR rollout continues with:

- **Step 4** — `MeteringQuery` read interface. UI and `check_quota` start reading from the log instead of Redis directly.
- **Step 5** — cut reads over behind a per-endpoint flag. Monitor drift daily (this reconciler is the safety net).
- **Step 6** — Parquet rollup to MinIO for >30-day history (the actual "data lake" half of the ADR).
- **Step 7** — backfill from the Redis counters we still have.
- **Step 8** — retire Redis TTLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
