### PR TITLE
feat(metering-v2): end-to-end healthcheck — CLI, HTTP, and pytest

### DIFF
--- a/src/clsplusplus/api.py
+++ b/src/clsplusplus/api.py
@@ -2105,6 +2105,25 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
             logger.error("Admin waitlist promote error: %s: %s", type(e).__name__, e)
             raise HTTPException(status_code=500, detail="Promote failed")
 
+    @app.get("/admin/metering/health")
+    async def admin_metering_health(request: Request):
+        """Run the full metering v2 health check and return a structured report.
+
+        Seven checks: config flag, oncall email, DB reachable, schema present,
+        writer roundtrip (canary insert + read-back), dead-letter clean,
+        reconciler runs without drift. Returns HTTP 200 when all pass,
+        HTTP 503 when any fail (so this can be used as a Render healthcheck
+        target if desired). Admin-only.
+        """
+        _require_admin(request)
+        from clsplusplus.metering_v2 import MeteringHealthCheck
+        check = MeteringHealthCheck(settings, _metering_pool, _metering_redis)
+        report = await check.run_all()
+        body = report.to_dict()
+        if report.passed:
+            return body
+        return JSONResponse(status_code=503, content=body)
+
     @app.post("/admin/metering/reconcile")
     async def admin_metering_reconcile(request: Request, period: Optional[str] = None):
         """Run the metering reconciler on demand and return the summary.

--- a/src/clsplusplus/metering_v2/__init__.py
+++ b/src/clsplusplus/metering_v2/__init__.py
@@ -8,6 +8,11 @@ Rollout defined in docs/adr/0001-metering-data-lake.md. Steps landed:
     step 3   — daily reconciliation vs Redis (this package)
 """
 
+from clsplusplus.metering_v2.healthcheck import (
+    CheckResult,
+    HealthReport,
+    MeteringHealthCheck,
+)
 from clsplusplus.metering_v2.notifier import MeteringNotifier
 from clsplusplus.metering_v2.pricing import MeteringPricer, compute_unit_cost_cents
 from clsplusplus.metering_v2.reconciler import (
@@ -32,8 +37,11 @@ __all__ = [
     "MeteringNotifier",
     "MeteringPricer",
     "MeteringReconciler",
+    "MeteringHealthCheck",
     "DriftFinding",
     "ReconciliationResult",
+    "HealthReport",
+    "CheckResult",
     "UsageEvent",
     "VALID_ACTOR_KINDS",
     "compute_unit_cost_cents",

--- a/src/clsplusplus/metering_v2/__main__.py
+++ b/src/clsplusplus/metering_v2/__main__.py
@@ -1,0 +1,32 @@
+"""CLI entry point:
+
+    python -m clsplusplus.metering_v2 healthcheck [--json]
+
+Exit code 0 = healthy, 1 = one or more checks failed.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def main() -> None:
+    argv = sys.argv[1:]
+    if not argv:
+        print(
+            "Usage: python -m clsplusplus.metering_v2 healthcheck [--json]",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    command = argv[0]
+    if command == "healthcheck":
+        from clsplusplus.metering_v2.healthcheck import main as _run
+        _run()
+    else:
+        print(f"Unknown command: {command}", file=sys.stderr)
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/clsplusplus/metering_v2/healthcheck.py
+++ b/src/clsplusplus/metering_v2/healthcheck.py
@@ -1,0 +1,381 @@
+"""End-to-end health check for the metering v2 pipeline.
+
+Turns the "is it working?" question into a single structured report.
+Can be run three ways:
+
+1. Python API — `MeteringHealthCheck(settings, pool_getter, redis_getter).run_all()`
+2. HTTP       — `GET /admin/metering/health` (wired in api.py)
+3. CLI        — `python -m clsplusplus.metering_v2 healthcheck`
+
+Each sub-check returns a structured result: name, ok, detail, remediation.
+An overall `passed` is computed from the logical-AND of all sub-checks.
+
+The roundtrip check writes a canary row into `usage_events` with
+`event_type="healthcheck"` and `actor_kind="system"`. Those rows are
+safe to ignore when aggregating for billing (actor_kind 'system' is
+not a billable actor).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+from dataclasses import dataclass, asdict, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Awaitable, Callable, Optional
+from uuid import uuid4
+
+from clsplusplus.config import Settings
+from clsplusplus.metering_v2.reconciler import MeteringReconciler
+from clsplusplus.metering_v2.writer import MeteringWriter, UsageEvent
+
+logger = logging.getLogger(__name__)
+
+
+PoolGetter = Callable[[], Awaitable[Any]]
+RedisGetter = Callable[[], Awaitable[Any]]
+
+
+@dataclass
+class CheckResult:
+    name: str
+    ok: bool
+    detail: str = ""
+    remediation: str = ""
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class HealthReport:
+    passed: bool
+    checks: list[CheckResult] = field(default_factory=list)
+    ran_at: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "passed": self.passed,
+            "ran_at": self.ran_at,
+            "checks": [c.to_dict() for c in self.checks],
+        }
+
+    def pretty(self) -> str:
+        """Fixed-width textual report."""
+        lines = [f"METERING V2 HEALTH — {'PASS' if self.passed else 'FAIL'} "
+                 f"(ran_at={self.ran_at})"]
+        for c in self.checks:
+            mark = "✓" if c.ok else "✗"
+            lines.append(f"  [{mark}] {c.name:35s} {c.detail}")
+            if not c.ok and c.remediation:
+                lines.append(f"        → {c.remediation}")
+        return "\n".join(lines)
+
+
+class MeteringHealthCheck:
+    """Runs every observable signal and returns a single report."""
+
+    def __init__(
+        self,
+        settings: Settings,
+        pool_getter: PoolGetter,
+        redis_getter: RedisGetter,
+        *,
+        drift_percent: float = 0.001,
+        min_abs_drift: int = 5,
+        canary_timeout_seconds: float = 5.0,
+    ):
+        self.settings = settings
+        self._pool_getter = pool_getter
+        self._redis_getter = redis_getter
+        self._drift_pct = drift_percent
+        self._min_abs = min_abs_drift
+        self._canary_timeout = canary_timeout_seconds
+
+    async def run_all(self) -> HealthReport:
+        checks: list[CheckResult] = []
+
+        # Order matters — later checks depend on earlier ones passing.
+        flag_check = self._check_flag_on()
+        checks.append(flag_check)
+        if not flag_check.ok:
+            return self._build_report(checks)
+
+        checks.append(self._check_oncall_set())
+
+        db_check = await self._check_database_reachable()
+        checks.append(db_check)
+        if not db_check.ok:
+            return self._build_report(checks)
+
+        schema_check = await self._check_schema_present()
+        checks.append(schema_check)
+        if not schema_check.ok:
+            return self._build_report(checks)
+
+        checks.append(await self._check_writer_roundtrip())
+        checks.append(await self._check_dead_letter_clean())
+        reconcile = await self._check_reconciler_runs()
+        checks.append(reconcile)
+
+        return self._build_report(checks)
+
+    def _build_report(self, checks: list[CheckResult]) -> HealthReport:
+        return HealthReport(
+            passed=all(c.ok for c in checks),
+            checks=checks,
+            ran_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        )
+
+    # --- individual checks -----------------------------------------
+
+    def _check_flag_on(self) -> CheckResult:
+        if self.settings.metering_v2_write_enabled:
+            return CheckResult("config.flag_on", True, "write path enabled")
+        return CheckResult(
+            "config.flag_on", False,
+            "CLS_METERING_V2_WRITE_ENABLED is false",
+            "Set CLS_METERING_V2_WRITE_ENABLED=true on Render and redeploy.",
+        )
+
+    def _check_oncall_set(self) -> CheckResult:
+        email = self.settings.oncall_email
+        if email:
+            return CheckResult("config.oncall_email", True, f"set to {email}")
+        return CheckResult(
+            "config.oncall_email", False,
+            "empty",
+            "Set CLS_ONCALL_EMAIL on Render; "
+            "dead-letter findings will not page anyone otherwise.",
+        )
+
+    async def _check_database_reachable(self) -> CheckResult:
+        try:
+            pool = await self._pool_getter()
+            async with pool.acquire() as conn:
+                await conn.fetchval("SELECT 1")
+            return CheckResult("db.reachable", True, "ok")
+        except Exception as exc:
+            return CheckResult(
+                "db.reachable", False,
+                f"{type(exc).__name__}: {exc}",
+                "Check CLS_DATABASE_URL and that Postgres is up.",
+            )
+
+    async def _check_schema_present(self) -> CheckResult:
+        try:
+            pool = await self._pool_getter()
+            async with pool.acquire() as conn:
+                rows = await conn.fetch(
+                    """SELECT table_name FROM information_schema.tables
+                       WHERE table_schema = current_schema()
+                         AND table_name IN ('usage_events', 'metering_dead_letter')"""
+                )
+            found = sorted(r["table_name"] for r in rows)
+            if found == ["metering_dead_letter", "usage_events"]:
+                return CheckResult("db.schema_present", True,
+                                   "usage_events + metering_dead_letter exist")
+            return CheckResult(
+                "db.schema_present", False,
+                f"found only {found}",
+                "Redeploy with CLS_METERING_V2_WRITE_ENABLED=true so the "
+                "startup hook applies the DDL, OR call "
+                "metering_v2.apply_schema() manually.",
+            )
+        except Exception as exc:
+            return CheckResult(
+                "db.schema_present", False,
+                f"{type(exc).__name__}: {exc}", "",
+            )
+
+    async def _check_writer_roundtrip(self) -> CheckResult:
+        """Write a canary event synchronously and read it back."""
+        canary_key = f"healthcheck-{uuid4()}"
+        event = UsageEvent(
+            idempotency_key=canary_key,
+            actor_kind="system",
+            actor_id="healthcheck",
+            event_type="healthcheck",
+            occurred_at=datetime.now(timezone.utc),
+            raw={"source": "MeteringHealthCheck"},
+        )
+        writer = MeteringWriter(self.settings, self._pool_getter)
+        try:
+            ok = await asyncio.wait_for(
+                writer.record_sync(event), timeout=self._canary_timeout,
+            )
+        except asyncio.TimeoutError:
+            return CheckResult(
+                "writer.roundtrip", False,
+                "writer timed out after %ss" % self._canary_timeout,
+                "Pool is blocking. Check pool size / idle connections / DB latency.",
+            )
+        except Exception as exc:
+            return CheckResult(
+                "writer.roundtrip", False,
+                f"{type(exc).__name__}: {exc}",
+                "Writer raised. Check the dead-letter table — the event may have "
+                "been enqueued there.",
+            )
+
+        if not ok:
+            return CheckResult(
+                "writer.roundtrip", False,
+                "record_sync returned False (enqueued to dead_letter instead)",
+                "Check metering_dead_letter for the canary key.",
+            )
+
+        # Verify the row shows up with the expected fields.
+        try:
+            pool = await self._pool_getter()
+            async with pool.acquire() as conn:
+                row = await conn.fetchrow(
+                    """SELECT event_type, quantity, unit_cost_cents,
+                              recorded_at
+                       FROM usage_events
+                       WHERE idempotency_key = $1""",
+                    canary_key,
+                )
+        except Exception as exc:
+            return CheckResult(
+                "writer.roundtrip", False,
+                f"read-back failed: {type(exc).__name__}: {exc}", "",
+            )
+
+        if row is None:
+            return CheckResult(
+                "writer.roundtrip", False,
+                "canary not found after write",
+                "Write silently dropped. This is the money-losing bug — "
+                "check logs for a suppressed exception in record_safely.",
+            )
+        if row["event_type"] != "healthcheck" or row["quantity"] != 1:
+            return CheckResult(
+                "writer.roundtrip", False,
+                f"row shape wrong: {dict(row)}", "",
+            )
+        return CheckResult(
+            "writer.roundtrip", True,
+            f"canary written + read back in <{self._canary_timeout}s",
+        )
+
+    async def _check_dead_letter_clean(self) -> CheckResult:
+        """No unpaged failures older than the notifier's poll cycle + grace."""
+        cutoff = datetime.now(timezone.utc) - timedelta(minutes=3)
+        try:
+            pool = await self._pool_getter()
+            async with pool.acquire() as conn:
+                stuck = await conn.fetchval(
+                    """SELECT COUNT(*)::INT FROM metering_dead_letter
+                       WHERE notified_at IS NULL AND failed_at < $1""",
+                    cutoff,
+                )
+                recent = await conn.fetchval(
+                    """SELECT COUNT(*)::INT FROM metering_dead_letter
+                       WHERE failed_at >= $1""",
+                    cutoff,
+                )
+        except Exception as exc:
+            return CheckResult(
+                "dead_letter.clean", False,
+                f"{type(exc).__name__}: {exc}", "",
+            )
+
+        if stuck == 0:
+            return CheckResult(
+                "dead_letter.clean", True,
+                f"0 stuck rows (recent <3m: {recent})",
+            )
+        return CheckResult(
+            "dead_letter.clean", False,
+            f"{stuck} row(s) unpaged > 3 minutes old",
+            "Notifier is stuck. Check logs for 'metering notifier:' errors; "
+            "likely Resend API down or CLS_ONCALL_EMAIL misconfigured.",
+        )
+
+    async def _check_reconciler_runs(self) -> CheckResult:
+        """Invoke reconcile_once and check drift."""
+        reconciler = MeteringReconciler(
+            self.settings, self._pool_getter, self._redis_getter,
+            drift_percent=self._drift_pct, min_abs_drift=self._min_abs,
+        )
+        try:
+            result = await reconciler.reconcile_once()
+        except Exception as exc:
+            return CheckResult(
+                "reconciler.runs", False,
+                f"{type(exc).__name__}: {exc}",
+                "Reconciler raised. Check Redis reachability and "
+                "metering_v2.reconciler logs.",
+            )
+        if result.findings:
+            return CheckResult(
+                "reconciler.drift", False,
+                f"{len(result.findings)} drift finding(s) in {result.period}",
+                "Investigate the enqueued ReconciliationDrift rows in "
+                "metering_dead_letter. Do NOT auto-fix — pick the correct "
+                "source of truth.",
+            )
+        return CheckResult(
+            "reconciler.drift", True,
+            f"0 drift (redis={result.redis_keys_seen}, "
+            f"pg={result.postgres_aggregates_seen}, "
+            f"{result.elapsed_seconds:.2f}s)",
+        )
+
+
+# --------------------------------------------------------------------------- #
+# CLI entry point — `python -m clsplusplus.metering_v2 healthcheck`
+# --------------------------------------------------------------------------- #
+
+
+async def _cli(as_json: bool) -> int:
+    settings = Settings()
+
+    async def pool_getter():
+        import asyncpg
+        url = settings.database_url
+        if url.startswith("postgresql://"):
+            url = url.replace("postgresql://", "postgres://", 1)
+        return await asyncpg.create_pool(url, min_size=1, max_size=2)
+
+    async def redis_getter():
+        try:
+            import redis.asyncio as _redis
+            return _redis.from_url(settings.redis_url, decode_responses=True)
+        except Exception:
+            return None
+
+    pool = None
+    try:
+        # Build one pool for the whole run rather than creating per-call.
+        pool = await pool_getter()
+
+        async def reuse_pool():
+            return pool
+
+        check = MeteringHealthCheck(settings, reuse_pool, redis_getter)
+        report = await check.run_all()
+        if as_json:
+            print(json.dumps(report.to_dict(), indent=2))
+        else:
+            print(report.pretty())
+        return 0 if report.passed else 1
+    finally:
+        if pool is not None:
+            await pool.close()
+
+
+def main() -> None:  # pragma: no cover (entry point)
+    as_json = "--json" in sys.argv
+    try:
+        exit_code = asyncio.run(_cli(as_json))
+    except KeyboardInterrupt:
+        exit_code = 130
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_metering_v2_healthcheck.py
+++ b/tests/test_metering_v2_healthcheck.py
@@ -1,0 +1,375 @@
+"""Pytest wrapper around MeteringHealthCheck.
+
+Two layers:
+
+1. Unit tests — each sub-check is exercised against fake DB / Redis.
+   Runs everywhere, no infra needed.
+
+2. Live suite — one test per sub-check, flipped on by setting
+   CLS_METERING_V2_LIVE_TEST=true plus real CLS_DATABASE_URL and
+   CLS_REDIS_URL. Each live test fails loudly with the sub-check's
+   own remediation string so the output is actionable.
+
+Usage against production:
+
+    CLS_METERING_V2_WRITE_ENABLED=true \\
+    CLS_METERING_V2_LIVE_TEST=true    \\
+    CLS_DATABASE_URL=<render-pg>      \\
+    CLS_REDIS_URL=<render-redis>      \\
+    python -m pytest tests/test_metering_v2_healthcheck.py -v
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pytest
+
+from clsplusplus.config import Settings
+from clsplusplus.metering_v2.healthcheck import (
+    CheckResult,
+    HealthReport,
+    MeteringHealthCheck,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Unit tests — fake infra
+# --------------------------------------------------------------------------- #
+
+
+class FakeConn:
+    def __init__(self, owner: "FakePool"):
+        self.owner = owner
+
+    async def fetchval(self, sql: str, *args):
+        if sql.strip() == "SELECT 1":
+            if self.owner.db_broken:
+                raise RuntimeError(self.owner.db_broken)
+            return 1
+        if "COUNT(*)" in sql and "notified_at IS NULL" in sql:
+            return self.owner.stuck_dead_letter
+        if "COUNT(*)" in sql and "failed_at >= $1" in sql:
+            return self.owner.recent_dead_letter
+        return 0
+
+    async def fetch(self, sql: str, *args):
+        if "information_schema.tables" in sql:
+            return [
+                {"table_name": t}
+                for t in self.owner.tables_present
+            ]
+        if "FROM usage_events" in sql:
+            return self.owner.pg_events
+        return []
+
+    async def fetchrow(self, sql: str, *args):
+        if "WHERE idempotency_key" in sql:
+            return self.owner.roundtrip_row
+        return None
+
+    async def execute(self, sql: str, *args):
+        if "INTO usage_events" in sql and self.owner.writer_fails_with:
+            raise RuntimeError(self.owner.writer_fails_with)
+        if "INTO usage_events" in sql:
+            self.owner.roundtrip_row = {
+                "event_type": args[6],
+                "quantity": args[7],
+                "unit_cost_cents": args[8],
+                "recorded_at": args[9],
+            }
+
+
+class _Acquire:
+    def __init__(self, conn):
+        self.conn = conn
+
+    async def __aenter__(self):
+        return self.conn
+
+    async def __aexit__(self, *a):
+        return None
+
+
+class FakePool:
+    def __init__(
+        self,
+        *,
+        db_broken: str | None = None,
+        tables_present: list[str] | None = None,
+        stuck_dead_letter: int = 0,
+        recent_dead_letter: int = 0,
+        writer_fails_with: str | None = None,
+        pg_events: list | None = None,
+    ):
+        self.db_broken = db_broken
+        self.tables_present = tables_present if tables_present is not None else [
+            "usage_events", "metering_dead_letter",
+        ]
+        self.stuck_dead_letter = stuck_dead_letter
+        self.recent_dead_letter = recent_dead_letter
+        self.writer_fails_with = writer_fails_with
+        self.roundtrip_row: dict | None = None
+        self.pg_events = pg_events or []
+
+    def acquire(self):
+        return _Acquire(FakeConn(self))
+
+
+class FakeRedis:
+    def __init__(self):
+        self.keys: dict[str, str] = {}
+
+    async def scan_iter(self, match: str, count: int = 500):
+        for _ in []:
+            yield _
+
+    async def get(self, key: str):
+        return None
+
+
+def _make_check(settings: Settings, pool: FakePool) -> MeteringHealthCheck:
+    async def pool_getter() -> Any:
+        return pool
+
+    async def redis_getter() -> Any:
+        return FakeRedis()
+
+    return MeteringHealthCheck(settings, pool_getter, redis_getter)
+
+
+@pytest.mark.asyncio
+async def test_flag_off_short_circuits():
+    report = await _make_check(
+        Settings(metering_v2_write_enabled=False), FakePool(),
+    ).run_all()
+    assert report.passed is False
+    assert report.checks[0].name == "config.flag_on"
+    assert report.checks[0].ok is False
+    # Short-circuits — no other checks attempted.
+    assert len(report.checks) == 1
+
+
+@pytest.mark.asyncio
+async def test_flag_on_oncall_set_progresses():
+    pool = FakePool()
+    report = await _make_check(
+        Settings(metering_v2_write_enabled=True,
+                 oncall_email="ops@example.com"),
+        pool,
+    ).run_all()
+    # First two pass; run_all continues past them.
+    assert report.checks[0].ok is True
+    assert report.checks[1].ok is True
+    assert report.checks[1].detail.startswith("set to")
+
+
+@pytest.mark.asyncio
+async def test_oncall_unset_flags_but_does_not_short_circuit():
+    pool = FakePool()
+    report = await _make_check(
+        Settings(metering_v2_write_enabled=True, oncall_email=""),
+        pool,
+    ).run_all()
+    names = [c.name for c in report.checks]
+    assert "config.oncall_email" in names
+    oncall = next(c for c in report.checks if c.name == "config.oncall_email")
+    assert oncall.ok is False
+    # Later checks still ran (oncall being empty is not a short-circuit).
+    assert "db.reachable" in names
+
+
+@pytest.mark.asyncio
+async def test_db_unreachable_short_circuits():
+    pool = FakePool(db_broken="ECONNREFUSED")
+    report = await _make_check(
+        Settings(metering_v2_write_enabled=True), pool,
+    ).run_all()
+    names = [c.name for c in report.checks]
+    assert "db.reachable" in names
+    db = next(c for c in report.checks if c.name == "db.reachable")
+    assert db.ok is False
+    # Schema/writer/DL checks NOT attempted.
+    assert "db.schema_present" not in names
+    assert "writer.roundtrip" not in names
+
+
+@pytest.mark.asyncio
+async def test_schema_missing_short_circuits():
+    pool = FakePool(tables_present=["usage_events"])  # missing dead_letter
+    report = await _make_check(
+        Settings(metering_v2_write_enabled=True), pool,
+    ).run_all()
+    schema = next(c for c in report.checks if c.name == "db.schema_present")
+    assert schema.ok is False
+    assert "found only" in schema.detail
+    # Writer/dead-letter checks skipped when schema missing.
+    names = [c.name for c in report.checks]
+    assert "writer.roundtrip" not in names
+
+
+@pytest.mark.asyncio
+async def test_writer_roundtrip_happy_path():
+    pool = FakePool()
+    report = await _make_check(
+        Settings(metering_v2_write_enabled=True), pool,
+    ).run_all()
+    rt = next(c for c in report.checks if c.name == "writer.roundtrip")
+    assert rt.ok is True
+
+
+@pytest.mark.asyncio
+async def test_writer_insert_fails_goes_to_dead_letter_and_reports_fail():
+    pool = FakePool(writer_fails_with="simulated connection refused")
+    # The writer's own error handling routes to dead-letter, so record_sync
+    # returns False and the round-trip reports failure with a clear message.
+    report = await _make_check(
+        Settings(metering_v2_write_enabled=True), pool,
+    ).run_all()
+    rt = next(c for c in report.checks if c.name == "writer.roundtrip")
+    assert rt.ok is False
+    assert "dead_letter" in rt.detail.lower() or "dead-letter" in rt.detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_dead_letter_stuck_rows_flag():
+    pool = FakePool(stuck_dead_letter=3, recent_dead_letter=0)
+    report = await _make_check(
+        Settings(metering_v2_write_enabled=True), pool,
+    ).run_all()
+    dl = next(c for c in report.checks if c.name == "dead_letter.clean")
+    assert dl.ok is False
+    assert "3" in dl.detail
+
+
+@pytest.mark.asyncio
+async def test_overall_passes_on_happy_path():
+    pool = FakePool()
+    report = await _make_check(
+        Settings(metering_v2_write_enabled=True,
+                 oncall_email="ops@example.com"),
+        pool,
+    ).run_all()
+    assert report.passed is True
+    assert all(c.ok for c in report.checks)
+
+
+# --------------------------------------------------------------------------- #
+# Pretty printer
+# --------------------------------------------------------------------------- #
+
+
+def test_report_pretty_marks_passes_and_failures():
+    report = HealthReport(
+        passed=False,
+        ran_at="2026-04-21T07:30:00+00:00",
+        checks=[
+            CheckResult("config.flag_on", True, "write path enabled"),
+            CheckResult("db.reachable", False, "ECONNREFUSED",
+                        "Check CLS_DATABASE_URL."),
+        ],
+    )
+    out = report.pretty()
+    assert "PASS" not in out  # overall is FAIL
+    assert "FAIL" in out
+    assert "✓" in out
+    assert "✗" in out
+    assert "Check CLS_DATABASE_URL." in out
+
+
+# --------------------------------------------------------------------------- #
+# Live suite — opt-in via CLS_METERING_V2_LIVE_TEST=true
+# --------------------------------------------------------------------------- #
+
+
+_LIVE = os.environ.get("CLS_METERING_V2_LIVE_TEST", "").lower() in {"1", "true", "yes"}
+pytestmark_live = pytest.mark.skipif(
+    not _LIVE,
+    reason="Set CLS_METERING_V2_LIVE_TEST=true + CLS_DATABASE_URL to run the "
+           "production health check as real pytest cases.",
+)
+
+
+async def _live_report() -> HealthReport:
+    """Build a healthcheck against the real infra described by env vars."""
+    settings = Settings()
+
+    import asyncpg
+    url = settings.database_url
+    if url.startswith("postgresql://"):
+        url = url.replace("postgresql://", "postgres://", 1)
+    pool = await asyncpg.create_pool(url, min_size=1, max_size=2)
+
+    async def pool_getter() -> Any:
+        return pool
+
+    async def redis_getter() -> Any:
+        try:
+            import redis.asyncio as _redis
+            return _redis.from_url(settings.redis_url, decode_responses=True)
+        except Exception:
+            return None
+
+    check = MeteringHealthCheck(settings, pool_getter, redis_getter)
+    try:
+        return await check.run_all()
+    finally:
+        await pool.close()
+
+
+@pytest.mark.asyncio
+@pytestmark_live
+async def test_live_overall_passes():
+    """Headline: the whole thing is healthy."""
+    report = await _live_report()
+    assert report.passed, "\n" + report.pretty()
+
+
+@pytest.mark.asyncio
+@pytestmark_live
+async def test_live_flag_on():
+    report = await _live_report()
+    c = next(c for c in report.checks if c.name == "config.flag_on")
+    assert c.ok, c.remediation or c.detail
+
+
+@pytest.mark.asyncio
+@pytestmark_live
+async def test_live_db_reachable():
+    report = await _live_report()
+    c = next(c for c in report.checks if c.name == "db.reachable")
+    assert c.ok, c.remediation or c.detail
+
+
+@pytest.mark.asyncio
+@pytestmark_live
+async def test_live_schema_present():
+    report = await _live_report()
+    c = next(c for c in report.checks if c.name == "db.schema_present")
+    assert c.ok, c.remediation or c.detail
+
+
+@pytest.mark.asyncio
+@pytestmark_live
+async def test_live_writer_roundtrip():
+    """Writes a canary usage_events row and reads it back."""
+    report = await _live_report()
+    c = next(c for c in report.checks if c.name == "writer.roundtrip")
+    assert c.ok, c.remediation or c.detail
+
+
+@pytest.mark.asyncio
+@pytestmark_live
+async def test_live_dead_letter_clean():
+    report = await _live_report()
+    c = next(c for c in report.checks if c.name == "dead_letter.clean")
+    assert c.ok, c.remediation or c.detail
+
+
+@pytest.mark.asyncio
+@pytestmark_live
+async def test_live_reconciler_no_drift():
+    report = await _live_report()
+    c = next(c for c in report.checks if c.name == "reconciler.drift")
+    assert c.ok, c.remediation or c.detail


### PR DESCRIPTION
## Summary

One pipeline that answers the question "is metering v2 actually working?" — reachable three ways:

| Entry point | How |
|---|---|
| **CLI** | `python -m clsplusplus.metering_v2 healthcheck` (exit 0 = pass, 1 = fail) |
| **HTTP** | `GET /admin/metering/health` → 200 when green, 503 when red |
| **pytest** | `CLS_METERING_V2_LIVE_TEST=true python -m pytest tests/test_metering_v2_healthcheck.py -v` |

All three share the same seven sub-checks inside `MeteringHealthCheck.run_all()`. Each result is `{name, ok, detail, remediation}` — failures tell you what to do next, not just "something is wrong".

## The seven checks

| # | Name | What it proves |
|---|---|---|
| 1 | `config.flag_on` | `CLS_METERING_V2_WRITE_ENABLED=true` |
| 2 | `config.oncall_email` | `CLS_ONCALL_EMAIL` is set (dead-letter pages someone) |
| 3 | `db.reachable` | `SELECT 1` against Postgres succeeds |
| 4 | `db.schema_present` | `usage_events` + `metering_dead_letter` tables exist |
| 5 | `writer.roundtrip` | Canary event inserts via the real `MeteringWriter` and is read back. `actor_kind='system'`, `event_type='healthcheck'` — billing aggregates filter those out. |
| 6 | `dead_letter.clean` | No rows with `notified_at IS NULL AND failed_at < now() - 3m` (notifier not stuck) |
| 7 | `reconciler.drift` | `reconcile_once()` returns zero drift findings vs. Redis |

Checks short-circuit sensibly: if the flag is off, nothing else runs; if the DB is down, schema/writer/DL/reconciler checks are skipped. You never see cascading failures from an unsatisfied prereq.

## Pretty CLI output

```
METERING V2 HEALTH — PASS (ran_at=2026-04-21T07:35:12+00:00)
  [✓] config.flag_on                       write path enabled
  [✓] config.oncall_email                  set to rjabbala@gmail.com
  [✓] db.reachable                         ok
  [✓] db.schema_present                    usage_events + metering_dead_letter exist
  [✓] writer.roundtrip                     canary written + read back in <5s
  [✓] dead_letter.clean                    0 stuck rows (recent <3m: 0)
  [✓] reconciler.drift                     0 drift (redis=12, pg=12, 0.08s)
```

Failure example:

```
METERING V2 HEALTH — FAIL (ran_at=2026-04-21T07:42:03+00:00)
  [✓] config.flag_on                       write path enabled
  [✓] config.oncall_email                  set to rjabbala@gmail.com
  [✓] db.reachable                         ok
  [✓] db.schema_present                    ...
  [✗] writer.roundtrip                     canary not found after write
        → Write silently dropped. This is the money-losing bug — check logs
          for a suppressed exception in record_safely.
```

## How to use it

### Against production (most useful)

```bash
curl -b "cls_session=<admin-session>" \
  https://api.clsplusplus.com/admin/metering/health
```

Returns 200 + body when healthy, 503 + same body when any check fails. Body is the full `HealthReport` JSON.

### As a cron / Render check

Point a Render Cron Job or external uptime monitor at `/admin/metering/health`. Non-2xx = page yourself.

### Locally during development

```
CLS_DATABASE_URL=postgresql://cls:cls@localhost:5433/cls \
CLS_REDIS_URL=redis://localhost:6379 \
CLS_METERING_V2_WRITE_ENABLED=true \
  python -m clsplusplus.metering_v2 healthcheck
```

### As pytest (for CI)

```
CLS_DATABASE_URL=... CLS_REDIS_URL=... \
CLS_METERING_V2_WRITE_ENABLED=true \
CLS_METERING_V2_LIVE_TEST=true \
  python -m pytest tests/test_metering_v2_healthcheck.py -v
```

One pytest case per sub-check, each with its own remediation string as the failure message.

## Tests in this PR

- **10 unit tests** (no infra): every short-circuit path, happy-path, pretty-printer.
- **7 live tests** (skipped unless `CLS_METERING_V2_LIVE_TEST=true`): run the healthcheck against real infra and assert each sub-check.

```
$ PYTHONPATH=src python3 -m pytest tests/test_metering_v2_healthcheck.py -v
10 passed, 7 skipped in 0.18s

$ PYTHONPATH=src python3 -m pytest tests/test_metering_v2_*.py -q
56 passed, 14 skipped in 0.52s
```

## What this PR does NOT do

- **No billing-logic changes.** Pure observability.
- **No auto-remediation.** Drift, dead-letter, missing schema — all surfaced, never auto-fixed. Picking the wrong source of truth is exactly the money-losing scenario the ADR guards against.
- **No new infra.** Uses the existing Postgres + Redis.

## Rollback

`git revert <merge-commit> && git push origin main`. The canary rows (`actor_kind='system'`, `event_type='healthcheck'`) are safe to leave in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
