### PR TITLE
ci: prod-smoke workflow — live E2E billing suite on schedule

### DIFF
--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -1,0 +1,138 @@
+name: Prod smoke (billing + metering)
+
+# Catches regressions that unit tests can't see — Render outages, bad env
+# vars, webhook secret drift, quota misconfiguration, expired OAuth creds.
+#
+# Runs:
+#   * every 15 minutes (catches infra regressions fast)
+#   * after every push to main (catches deploy-time breakage)
+#   * manually via workflow_dispatch (for debugging)
+#
+# Required GitHub secrets (set via repo → Settings → Secrets → Actions):
+#   CLS_E2E_ADMIN_EMAIL    — email of an admin user on prod
+#   CLS_E2E_ADMIN_PASSWORD — that user's password
+#
+# When the secrets are absent the job self-skips with a warning rather than
+# spamming failure emails. Set them to turn the gate on.
+#
+# Optional secrets:
+#   CLS_E2E_BASE_URL  — override production URL (default: https://www.clsplusplus.com)
+#   SLACK_WEBHOOK_URL — if set, posts to Slack on failure
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Override base URL (blank = use secret or default)'
+        required: false
+        default: ''
+
+concurrency:
+  group: prod-smoke
+  cancel-in-progress: false
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check required secrets are configured
+        id: have_secrets
+        env:
+          HAVE_EMAIL: ${{ secrets.CLS_E2E_ADMIN_EMAIL != '' }}
+          HAVE_PASSWORD: ${{ secrets.CLS_E2E_ADMIN_PASSWORD != '' }}
+        run: |
+          if [ "$HAVE_EMAIL" = "true" ] && [ "$HAVE_PASSWORD" = "true" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Prod smoke disabled::Set CLS_E2E_ADMIN_EMAIL + CLS_E2E_ADMIN_PASSWORD secrets to enable live regression checks."
+          fi
+
+      - name: Set up Python
+        if: steps.have_secrets.outputs.configured == 'true'
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install minimal deps (httpx + pytest only)
+        if: steps.have_secrets.outputs.configured == 'true'
+        run: pip install --upgrade 'httpx<1' 'pytest>=8' 'pytest-asyncio>=1'
+
+      - name: Resolve base URL
+        if: steps.have_secrets.outputs.configured == 'true'
+        id: url
+        run: |
+          URL="${{ github.event.inputs.base_url }}"
+          [ -z "$URL" ] && URL="${{ secrets.CLS_E2E_BASE_URL }}"
+          [ -z "$URL" ] && URL="https://www.clsplusplus.com"
+          echo "base=$URL" >> "$GITHUB_OUTPUT"
+          echo "Using base URL: $URL"
+
+      - name: Log in as admin (fresh cls_session cookie)
+        if: steps.have_secrets.outputs.configured == 'true'
+        id: login
+        env:
+          BASE_URL: ${{ steps.url.outputs.base }}
+          ADMIN_EMAIL: ${{ secrets.CLS_E2E_ADMIN_EMAIL }}
+          ADMIN_PASSWORD: ${{ secrets.CLS_E2E_ADMIN_PASSWORD }}
+        run: |
+          HTTP=$(curl -sS -o /tmp/login.json -w '%{http_code}' \
+            -X POST "$BASE_URL/api/v1/auth/login" \
+            -H 'Content-Type: application/json' \
+            -c /tmp/cookies.txt \
+            -d "{\"email\":\"$ADMIN_EMAIL\",\"password\":\"$ADMIN_PASSWORD\"}")
+          if [ "$HTTP" -lt 200 ] || [ "$HTTP" -ge 300 ]; then
+            echo "::error title=Login failed::HTTP $HTTP from /v1/auth/login. Check CLS_E2E_ADMIN_EMAIL/PASSWORD."
+            cat /tmp/login.json
+            exit 1
+          fi
+          COOKIE=$(awk '/cls_session/ {print $7}' /tmp/cookies.txt | tail -1)
+          if [ -z "$COOKIE" ]; then
+            echo "::error title=No cookie::Login returned 2xx but no cls_session cookie."
+            cat /tmp/cookies.txt
+            exit 1
+          fi
+          echo "::add-mask::$COOKIE"
+          echo "cookie=$COOKIE" >> "$GITHUB_OUTPUT"
+
+      - name: Run billing E2E pytest suite
+        if: steps.have_secrets.outputs.configured == 'true'
+        env:
+          CLS_E2E_BASE_URL: ${{ steps.url.outputs.base }}
+          CLS_E2E_ADMIN_COOKIE: ${{ steps.login.outputs.cookie }}
+        run: pytest tests/test_billing_e2e.py -v --tb=short
+
+      - name: Dump metering diagnostics on failure
+        if: failure() && steps.login.outputs.cookie != ''
+        env:
+          CLS_E2E_BASE_URL: ${{ steps.url.outputs.base }}
+          CLS_E2E_ADMIN_COOKIE: ${{ steps.login.outputs.cookie }}
+        run: |
+          echo "== Metering health at failure =="
+          curl -sS -b "cls_session=$CLS_E2E_ADMIN_COOKIE" \
+            "$CLS_E2E_BASE_URL/api/admin/metering/health" | python -m json.tool || true
+          echo ""
+          echo "== Reconciler at failure =="
+          curl -sS -X POST -b "cls_session=$CLS_E2E_ADMIN_COOKIE" \
+            "$CLS_E2E_BASE_URL/api/admin/metering/reconcile" | python -m json.tool || true
+
+      - name: Notify Slack on failure
+        if: failure() && steps.have_secrets.outputs.configured == 'true'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_WEBHOOK_URL not set — skipping Slack notification."
+            exit 0
+          fi
+          curl -sS -X POST -H 'Content-Type: application/json' \
+            --data "{\"text\":\"🚨 CLS++ prod smoke FAILED\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"}" \
+            "$SLACK_WEBHOOK_URL" || true


### PR DESCRIPTION
## Summary

Adds a **prod-smoke** GitHub Actions workflow that runs the E2E billing suite (from [#431](https://github.com/rajamohan1950/CLSplusplus/pull/431)) against production every 15 minutes, after every push to main, and on manual dispatch. Catches the class of regressions unit tests cannot see:

- Render outage or bad deploy
- Webhook secret rotation drift
- Env var misconfiguration (`CLS_METERING_V2_WRITE_ENABLED` flipped off accidentally, etc.)
- OAuth creds expired / redirect URI mismatch re-introduced
- DB schema drift
- CDN / Vercel routing breakage

## Unit tests already run in CI

The existing `ci.yml` workflow runs `pytest tests/` on every push/PR with Postgres + Redis services. All the new unit tests (`test_metering_v2_*`, `test_tier_resolver`, `test_subscription_watchdog`, `test_razorpay_subscription_webhooks`, etc.) are picked up automatically. The live `test_billing_e2e.py` has a module-level skipif on the two env vars, so it no-ops in unit CI.

## How the workflow protects you

```
schedule: */15 * * * *           # every 15 min
push: branches: [main]           # post-deploy smoke
workflow_dispatch: ...           # on-demand debugging

concurrency: prod-smoke           # never stacks parallel runs
timeout: 5 min                    # can't wedge forever
```

Each run:

1. Checks the two admin secrets are present. **If either is missing, the job self-skips with a warning** (no spam in the first days after merge while you set up secrets).
2. `POST /v1/auth/login` to get a fresh `cls_session` cookie. Masks it in logs.
3. `pytest tests/test_billing_e2e.py -v --tb=short` with the fresh cookie.
4. On failure: dumps `/admin/metering/health` and `/admin/metering/reconcile` output into the run log so you see exactly what's wrong without re-running manually.
5. On failure + `SLACK_WEBHOOK_URL` secret present: posts a Slack alert with a link to the failing run.

## Secrets you'll need to add (repo → Settings → Secrets → Actions)

| Secret | Required? | Purpose |
|---|---|---|
| `CLS_E2E_ADMIN_EMAIL` | **yes** | Admin user that can hit `/admin/*` endpoints |
| `CLS_E2E_ADMIN_PASSWORD` | **yes** | That user's password |
| `CLS_E2E_BASE_URL` | no (defaults to `https://www.clsplusplus.com`) | Override for a staging stack |
| `SLACK_WEBHOOK_URL` | no (optional alerting) | Posts failure notifications |

**Recommended**: create a dedicated service account (e.g. `ci-smoke@clsplusplus.com`) with `is_admin=true`, use a long random password stored only in GitHub Secrets. Never the owner's personal account.

Until the secrets are set, the workflow runs on schedule but short-circuits to a no-op with a `::warning::` annotation on the run summary.

## Why per-run login instead of a stored cookie

- **Cookie secrets leak into logs.** Even with masking, one wrong `set -x` in a shell step and the JWT is in your Actions history.
- **Cookies expire.** 7-day default — someone has to remember to rotate.
- **Logging in per run** means the cookie is ephemeral and scoped to the one workflow run.

## Rollback

`git revert <merge commit> && git push origin main`. Nothing persistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
