### PR TITLE
Weblab: PostHog-backed staged rollouts with auto-rollback

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -142,6 +142,36 @@ async function updateBadge() {
 updateBadge();
 setInterval(updateBadge, 60000);
 
+// ── Weblab feature flags ──
+// Fetches the evaluated PostHog flags for this user and caches them so
+// content scripts can branch on a treatment (control / T1 / T2) without an
+// extension redeploy. Fails silent — no flags just means default behaviour.
+async function fetchFlags() {
+  const key = await getKey();
+  if (!key) return {};
+  try {
+    const r = await fetch(`${API}/v1/config/flags`, {
+      headers: { 'Authorization': `Bearer ${key}` },
+    });
+    if (r.ok) {
+      const d = await r.json();
+      const flags = d.flags || {};
+      await chrome.storage.local.set({ cls_weblab_flags: flags });
+      return flags;
+    }
+  } catch (_) {}
+  return {};
+}
+
+async function getFlag(name, fallback) {
+  const { cls_weblab_flags } = await chrome.storage.local.get('cls_weblab_flags');
+  const flags = cls_weblab_flags || {};
+  return (name in flags) ? flags[name] : (fallback !== undefined ? fallback : false);
+}
+
+fetchFlags();
+setInterval(fetchFlags, 600000);  // refresh every 10 minutes
+
 // ── Message handler ──
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   // CORE — store memory (proven path from v5.1.0)
@@ -203,6 +233,12 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     incrementDailyCounter('cls_daily_injected');
     sendResponse({ ok: true });
     return false;
+  }
+
+  // Weblab — read a cached feature-flag treatment (control / T1 / T2 / bool)
+  if (msg.type === 'GET_FLAG') {
+    getFlag(msg.name, msg.fallback).then(value => sendResponse({ value }));
+    return true;
   }
 
   // Popup — verify API key

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ server = [
     "razorpay>=1.4.0",
     "minio>=7.2.0",
     "pyarrow>=14.0.0",
+    "posthog>=3.5.0",
 ]
 dev = [
     "pytest>=7.4.0",

--- a/requirements-render.txt
+++ b/requirements-render.txt
@@ -22,3 +22,4 @@ PyJWT>=2.8.0
 stripe>=8.0.0
 razorpay>=1.4.0
 sentry-sdk[fastapi]>=2.0.0
+posthog>=3.5.0

--- a/src/clsplusplus/api.py
+++ b/src/clsplusplus/api.py
@@ -147,6 +147,11 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
     _overage_biller = None
     _subscription_watchdog = None
 
+    # Weblab auto-rollback watcher — polls ops-health and disables a PostHog
+    # flag when its metrics breach thresholds. Started in startup() below.
+    from clsplusplus.weblab_watcher import WeblabWatcher
+    _weblab_watcher = WeblabWatcher(settings)
+
     async def _metering_redis():
         """Lazy Redis client for the reconciler. Returns None if unavailable."""
         try:
@@ -401,6 +406,41 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
     async def analytics_dashboard_config():
         """Return PostHog shared dashboard URL from environment. No auth required (admin-only page)."""
         return {"dashboard_url": os.environ.get("POSTHOG_DASHBOARD_URL", "")}
+
+    @app.get("/v1/config/flags")
+    async def weblab_flags(request: Request):
+        """Evaluated weblab feature flags for the calling identity.
+
+        The extension fetches this with its API key; treatment assignment is
+        keyed on the caller's namespace so a user always sees the same arm.
+        """
+        from clsplusplus import weblab
+        distinct_id = (
+            getattr(request.state, "namespace", None)
+            or getattr(request.state, "user_id", None)
+            or "anonymous"
+        )
+        return {
+            "flags": weblab.all_flags(distinct_id, settings),
+            "distinct_id": distinct_id,
+        }
+
+    @app.get("/admin/weblab")
+    async def admin_weblab_status(request: Request):
+        """Weblab control status — watched flags + latest green/red verdict."""
+        _require_admin(request)
+        verdict = await _weblab_watcher.evaluate()
+        return {
+            "launch_flag": settings.weblab_launch_flag,
+            "auto_rollback_enabled": settings.weblab_auto_rollback_enabled,
+            "thresholds": {
+                "error_rate_5xx_pct": settings.weblab_rollback_5xx_pct,
+                "p95_ms": settings.weblab_rollback_p95_ms,
+                "min_requests": settings.weblab_rollback_min_requests,
+            },
+            "verdict": verdict,
+            "last_watcher_result": _weblab_watcher.last_result,
+        }
 
     # Per-user metrics emitter (shared across all endpoints)
     from clsplusplus.metrics import MetricsEmitter
@@ -1257,6 +1297,25 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
         if not is_region_allowed(_country, settings):
             return JSONResponse(
                 content=await queue_out_of_region(waitlist_service, req.email)
+            )
+
+        # launch-rollout weblab: the PostHog flag is the percentage dial for
+        # who gets an active account now vs. the waitlist. Fails OPEN (default
+        # True) so a PostHog outage never blocks signups — the cap below is
+        # still the hard ceiling.
+        from clsplusplus import weblab
+        if not weblab.enabled(settings.weblab_launch_flag, req.email, settings,
+                              default=True):
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "launch_wave",
+                    "message": (
+                        "We're releasing CLS++ in small waves. Join the "
+                        "waitlist and we'll email you the moment your wave opens."
+                    ),
+                    "waitlist": True,
+                },
             )
 
         try:
@@ -3438,9 +3497,24 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
 
         asyncio.create_task(_waitlist_promoter_loop())
 
+        # ── 4. Weblab auto-rollback watcher ────────────────────────────────
+        try:
+            _weblab_watcher.start()
+            _api_logger.info(
+                "weblab watcher: started (poll=%ss, auto_rollback=%s)",
+                settings.weblab_metric_poll_seconds,
+                settings.weblab_auto_rollback_enabled,
+            )
+        except Exception as e:
+            _api_logger.warning("weblab watcher: start failed: %s", e)
+
     @app.on_event("shutdown")
     async def shutdown():
         """Cleanly close all connection pools on shutdown."""
+        try:
+            await _weblab_watcher.stop()
+        except Exception:
+            pass
         for store in [memory_service.l1, memory_service.l2]:
             if hasattr(store, "close"):
                 try:

--- a/src/clsplusplus/api.py
+++ b/src/clsplusplus/api.py
@@ -2537,85 +2537,11 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
                 overview[name] = {"error": e.detail}
             except Exception as e:  # noqa: BLE001
                 overview[name] = {"error": str(e)}
+        overview["links"] = {
+            "sentry": settings.sentry_url,
+            "posthog": os.environ.get("POSTHOG_DASHBOARD_URL", ""),
+        }
         return overview
-
-    @app.get("/admin/metrics/dashboard", response_class=HTMLResponse)
-    async def admin_metrics_dashboard(request: Request):
-        """Server-rendered single-pane metrics dashboard.
-
-        Consolidates the internal metrics inline; Sentry and PostHog (the
-        other two surfaces) are reached via deep-link buttons.
-        """
-        _require_admin(request)
-        data = await admin_metrics_overview(request)
-
-        oh = data.get("ops_health", {}) or {}
-        sm = data.get("summary", {}) or {}
-        wl = data.get("weblab", {}) or {}
-        verdict = wl.get("verdict") or {}
-        lat = oh.get("latency_ms") or {}
-        signups = (data.get("signups", {}) or {}).get("signups", []) or []
-        last7 = sum((s.get("count", 0) for s in signups[-7:])) if signups else 0
-
-        status = str(verdict.get("status", "unknown"))
-        status_color = {"green": "#1a7f37", "red": "#cf222e"}.get(status, "#9a6700")
-        posthog_url = os.environ.get("POSTHOG_DASHBOARD_URL", "") or "https://posthog.com"
-        sentry_url = settings.sentry_url
-
-        def card(label: str, value, sub: str = "") -> str:
-            return (f'<div class="card"><div class="label">{label}</div>'
-                    f'<div class="value">{value}</div>'
-                    f'<div class="sub">{sub}</div></div>')
-
-        html = f"""<!doctype html>
-<html><head><meta charset="utf-8"><title>CLS++ Metrics</title>
-<style>
-body{{font-family:-apple-system,system-ui,sans-serif;background:#0d1117;color:#e6edf3;margin:0;padding:24px}}
-h1{{font-size:20px;margin:0 0 4px}} .meta{{color:#8b949e;font-size:13px;margin-bottom:20px}}
-.grid{{display:flex;flex-wrap:wrap;gap:14px}}
-.card{{background:#161b22;border:1px solid #30363d;border-radius:10px;padding:16px 18px;min-width:150px}}
-.label{{color:#8b949e;font-size:12px;text-transform:uppercase;letter-spacing:.04em}}
-.value{{font-size:26px;font-weight:600;margin-top:6px}} .sub{{color:#8b949e;font-size:12px;margin-top:4px}}
-.verdict{{display:inline-block;padding:4px 12px;border-radius:999px;font-weight:600;font-size:13px;color:#fff}}
-.section{{font-size:13px;text-transform:uppercase;color:#8b949e;letter-spacing:.04em;margin:22px 0 10px}}
-code{{background:#21262d;padding:2px 6px;border-radius:4px}}
-a.btn{{display:inline-block;background:#21262d;border:1px solid #30363d;color:#e6edf3;text-decoration:none;
-padding:10px 18px;border-radius:8px;margin-right:10px;font-weight:600}}
-a.btn:hover{{background:#30363d}}
-</style></head><body>
-<h1>CLS++ — Launch Metrics</h1>
-<div class="meta">One pane over ops-health, KPIs, signups and weblab. Auto-refreshes every 60s.</div>
-
-<div class="section">Rollout health</div>
-<div style="margin-bottom:6px">
-  <span class="verdict" style="background:{status_color}">{status.upper()}</span>
-  &nbsp; weblab <code>{wl.get("launch_flag", "-")}</code> ·
-  auto-rollback {"ON" if wl.get("auto_rollback_enabled") else "OFF"}
-</div>
-
-<div class="section">Operations</div>
-<div class="grid">
-  {card("Requests", oh.get("total_requests", "-"))}
-  {card("Error rate", f'{oh.get("error_rate", 0)}%')}
-  {card("5xx rate", f'{oh.get("error_rate_5xx", 0)}%')}
-  {card("p95 latency", f'{lat.get("p95", "-")} ms')}
-</div>
-
-<div class="section">Business</div>
-<div class="grid">
-  {card("Total users", sm.get("total_users", "-"))}
-  {card("Paying", sm.get("paying_users", "-"))}
-  {card("MRR", f'${sm.get("monthly_revenue", "-")}')}
-  {card("Signups (7d)", last7)}
-</div>
-
-<div class="section">Deep dive</div>
-<a class="btn" href="{sentry_url}" target="_blank" rel="noopener">Errors &rarr; Sentry</a>
-<a class="btn" href="{posthog_url}" target="_blank" rel="noopener">Product &rarr; PostHog</a>
-
-<script>setTimeout(function(){{location.reload()}},60000)</script>
-</body></html>"""
-        return HTMLResponse(content=html)
 
     # =========================================================================
     # Admin — Launch waitlist view + lifecycle test runner

--- a/src/clsplusplus/api.py
+++ b/src/clsplusplus/api.py
@@ -2514,6 +2514,109 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
             logger.error("Admin storage metrics error: %s: %s", type(e).__name__, e)
             raise HTTPException(status_code=500, detail="Storage metrics unavailable")
 
+    @app.get("/admin/metrics/overview")
+    async def admin_metrics_overview(request: Request):
+        """Single aggregated payload — ops-health, KPIs, signups, weblab.
+
+        Fans out to the individual /admin/metrics/* handlers in-process so
+        there is one source of truth and no duplicated metric logic. A
+        failing source degrades to an {"error": ...} entry, never a 500.
+        """
+        _require_admin(request)
+        sources = {
+            "ops_health": admin_ops_health,
+            "summary": admin_summary,
+            "signups": admin_signups,
+            "weblab": admin_weblab_status,
+        }
+        overview: dict = {}
+        for name, handler in sources.items():
+            try:
+                overview[name] = await handler(request)
+            except HTTPException as e:
+                overview[name] = {"error": e.detail}
+            except Exception as e:  # noqa: BLE001
+                overview[name] = {"error": str(e)}
+        return overview
+
+    @app.get("/admin/metrics/dashboard", response_class=HTMLResponse)
+    async def admin_metrics_dashboard(request: Request):
+        """Server-rendered single-pane metrics dashboard.
+
+        Consolidates the internal metrics inline; Sentry and PostHog (the
+        other two surfaces) are reached via deep-link buttons.
+        """
+        _require_admin(request)
+        data = await admin_metrics_overview(request)
+
+        oh = data.get("ops_health", {}) or {}
+        sm = data.get("summary", {}) or {}
+        wl = data.get("weblab", {}) or {}
+        verdict = wl.get("verdict") or {}
+        lat = oh.get("latency_ms") or {}
+        signups = (data.get("signups", {}) or {}).get("signups", []) or []
+        last7 = sum((s.get("count", 0) for s in signups[-7:])) if signups else 0
+
+        status = str(verdict.get("status", "unknown"))
+        status_color = {"green": "#1a7f37", "red": "#cf222e"}.get(status, "#9a6700")
+        posthog_url = os.environ.get("POSTHOG_DASHBOARD_URL", "") or "https://posthog.com"
+        sentry_url = settings.sentry_url
+
+        def card(label: str, value, sub: str = "") -> str:
+            return (f'<div class="card"><div class="label">{label}</div>'
+                    f'<div class="value">{value}</div>'
+                    f'<div class="sub">{sub}</div></div>')
+
+        html = f"""<!doctype html>
+<html><head><meta charset="utf-8"><title>CLS++ Metrics</title>
+<style>
+body{{font-family:-apple-system,system-ui,sans-serif;background:#0d1117;color:#e6edf3;margin:0;padding:24px}}
+h1{{font-size:20px;margin:0 0 4px}} .meta{{color:#8b949e;font-size:13px;margin-bottom:20px}}
+.grid{{display:flex;flex-wrap:wrap;gap:14px}}
+.card{{background:#161b22;border:1px solid #30363d;border-radius:10px;padding:16px 18px;min-width:150px}}
+.label{{color:#8b949e;font-size:12px;text-transform:uppercase;letter-spacing:.04em}}
+.value{{font-size:26px;font-weight:600;margin-top:6px}} .sub{{color:#8b949e;font-size:12px;margin-top:4px}}
+.verdict{{display:inline-block;padding:4px 12px;border-radius:999px;font-weight:600;font-size:13px;color:#fff}}
+.section{{font-size:13px;text-transform:uppercase;color:#8b949e;letter-spacing:.04em;margin:22px 0 10px}}
+code{{background:#21262d;padding:2px 6px;border-radius:4px}}
+a.btn{{display:inline-block;background:#21262d;border:1px solid #30363d;color:#e6edf3;text-decoration:none;
+padding:10px 18px;border-radius:8px;margin-right:10px;font-weight:600}}
+a.btn:hover{{background:#30363d}}
+</style></head><body>
+<h1>CLS++ — Launch Metrics</h1>
+<div class="meta">One pane over ops-health, KPIs, signups and weblab. Auto-refreshes every 60s.</div>
+
+<div class="section">Rollout health</div>
+<div style="margin-bottom:6px">
+  <span class="verdict" style="background:{status_color}">{status.upper()}</span>
+  &nbsp; weblab <code>{wl.get("launch_flag", "-")}</code> ·
+  auto-rollback {"ON" if wl.get("auto_rollback_enabled") else "OFF"}
+</div>
+
+<div class="section">Operations</div>
+<div class="grid">
+  {card("Requests", oh.get("total_requests", "-"))}
+  {card("Error rate", f'{oh.get("error_rate", 0)}%')}
+  {card("5xx rate", f'{oh.get("error_rate_5xx", 0)}%')}
+  {card("p95 latency", f'{lat.get("p95", "-")} ms')}
+</div>
+
+<div class="section">Business</div>
+<div class="grid">
+  {card("Total users", sm.get("total_users", "-"))}
+  {card("Paying", sm.get("paying_users", "-"))}
+  {card("MRR", f'${sm.get("monthly_revenue", "-")}')}
+  {card("Signups (7d)", last7)}
+</div>
+
+<div class="section">Deep dive</div>
+<a class="btn" href="{sentry_url}" target="_blank" rel="noopener">Errors &rarr; Sentry</a>
+<a class="btn" href="{posthog_url}" target="_blank" rel="noopener">Product &rarr; PostHog</a>
+
+<script>setTimeout(function(){{location.reload()}},60000)</script>
+</body></html>"""
+        return HTMLResponse(content=html)
+
     # =========================================================================
     # Admin — Launch waitlist view + lifecycle test runner
     # =========================================================================

--- a/src/clsplusplus/config.py
+++ b/src/clsplusplus/config.py
@@ -257,6 +257,25 @@ class Settings(BaseSettings):
     circuit_failure_threshold: int = 5        # CLS_CIRCUIT_FAILURE_THRESHOLD
     circuit_recovery_seconds: float = 30.0    # CLS_CIRCUIT_RECOVERY_SECONDS
 
+    # ── Weblab: PostHog-backed staged rollouts + auto-rollback ────────────
+    # A "weblab" is a PostHog feature flag — a percentage dial with optional
+    # treatments (control / T1 / T2). `weblab_launch_flag` gates the share of
+    # new signups that get an active account vs. the waitlist. The watcher
+    # polls ops-health and disables a flag when its metrics breach thresholds.
+    posthog_api_key: str = ""                 # CLS_POSTHOG_API_KEY (project key)
+    posthog_personal_api_key: str = ""        # CLS_POSTHOG_PERSONAL_API_KEY (mgmt API + local eval)
+    posthog_project_id: str = ""              # CLS_POSTHOG_PROJECT_ID (for the management API)
+    posthog_host: str = "https://us.i.posthog.com"    # CLS_POSTHOG_HOST (SDK / flag eval)
+    posthog_api_host: str = "https://us.posthog.com"  # CLS_POSTHOG_API_HOST (management API)
+    weblab_launch_flag: str = "launch-rollout"        # CLS_WEBLAB_LAUNCH_FLAG
+    weblab_auto_rollback_enabled: bool = False        # CLS_WEBLAB_AUTO_ROLLBACK_ENABLED
+    weblab_watched_flags: str = "launch-rollout"      # CLS_WEBLAB_WATCHED_FLAGS (comma-separated)
+    weblab_metric_poll_seconds: int = 300             # CLS_WEBLAB_METRIC_POLL_SECONDS
+    weblab_health_window_minutes: int = 60            # CLS_WEBLAB_HEALTH_WINDOW_MINUTES
+    weblab_rollback_5xx_pct: float = 2.0              # CLS_WEBLAB_ROLLBACK_5XX_PCT
+    weblab_rollback_p95_ms: int = 3000                # CLS_WEBLAB_ROLLBACK_P95_MS
+    weblab_rollback_min_requests: int = 50            # CLS_WEBLAB_ROLLBACK_MIN_REQUESTS
+
     # Error tracking (Sentry). Leave empty to disable — when set, unhandled
     # exceptions are reported to Sentry with request context.
     sentry_dsn: str = ""                      # CLS_SENTRY_DSN

--- a/src/clsplusplus/config.py
+++ b/src/clsplusplus/config.py
@@ -279,6 +279,8 @@ class Settings(BaseSettings):
     # Error tracking (Sentry). Leave empty to disable — when set, unhandled
     # exceptions are reported to Sentry with request context.
     sentry_dsn: str = ""                      # CLS_SENTRY_DSN
+    # Sentry project URL — the "Errors" deep-link on the admin metrics page.
+    sentry_url: str = "https://sentry.io"     # CLS_SENTRY_URL
 
     # Demo LLM keys (optional; demo uses these for real Claude/OpenAI/Gemini)
     anthropic_api_key: Optional[str] = None

--- a/src/clsplusplus/weblab.py
+++ b/src/clsplusplus/weblab.py
@@ -1,0 +1,103 @@
+"""Weblab — PostHog-backed staged feature rollouts.
+
+A "weblab" is a PostHog feature flag. A boolean flag gates a feature for a
+rollout percentage; a multivariate flag assigns a treatment (control / T1 /
+T2 / ...). Assignment is deterministic per `distinct_id` — PostHog hashes it,
+so a given user always lands in the same treatment as the dial moves.
+
+Every call fails SAFE: if PostHog is unconfigured or unreachable, the helpers
+return the caller-supplied default rather than raising. The launch-rollout
+gate must never block signups because of a PostHog outage.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from clsplusplus.config import Settings
+
+logger = logging.getLogger(__name__)
+
+# Module-level singleton — building the client downloads flag definitions for
+# local evaluation, so we keep one per process.
+_client = None
+_client_failed = False
+
+
+def _get_client(settings: Settings):
+    """Lazily build the PostHog client. Returns None when unavailable."""
+    global _client, _client_failed
+    if _client is not None or _client_failed:
+        return _client
+    if not settings.posthog_api_key:
+        _client_failed = True
+        return None
+    try:
+        from posthog import Posthog
+
+        _client = Posthog(
+            project_api_key=settings.posthog_api_key,
+            host=settings.posthog_host,
+            # A personal key enables local flag evaluation (no per-call
+            # network round-trip). Optional — without it the SDK calls out.
+            personal_api_key=settings.posthog_personal_api_key or None,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning("weblab: PostHog client init failed: %s", e)
+        _client_failed = True
+        _client = None
+    return _client
+
+
+def reset_client() -> None:
+    """Drop the cached client — used by tests."""
+    global _client, _client_failed
+    _client = None
+    _client_failed = False
+
+
+def enabled(flag: str, distinct_id: str, settings: Settings,
+            default: bool = False) -> bool:
+    """True if `distinct_id` is rolled into `flag`. Fails safe to `default`."""
+    client = _get_client(settings)
+    if client is None:
+        return default
+    try:
+        return bool(client.feature_enabled(flag, distinct_id))
+    except Exception as e:  # noqa: BLE001
+        logger.warning("weblab: feature_enabled(%s) failed: %s", flag, e)
+        return default
+
+
+def treatment(flag: str, distinct_id: str, settings: Settings,
+              default: str = "control") -> str:
+    """Treatment variant for `distinct_id` on a multivariate `flag`.
+
+    Returns the variant key (e.g. "control", "T1", "T2"). A boolean-True flag
+    maps to "T1"; False / missing maps to `default`.
+    """
+    client = _get_client(settings)
+    if client is None:
+        return default
+    try:
+        val = client.get_feature_flag(flag, distinct_id)
+        if val is True:
+            return "T1"
+        if val is False or val is None:
+            return default
+        return str(val)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("weblab: get_feature_flag(%s) failed: %s", flag, e)
+        return default
+
+
+def all_flags(distinct_id: str, settings: Settings) -> dict:
+    """Every flag value for `distinct_id` — feeds the /v1/config/flags route."""
+    client = _get_client(settings)
+    if client is None:
+        return {}
+    try:
+        return client.get_all_flags(distinct_id) or {}
+    except Exception as e:  # noqa: BLE001
+        logger.warning("weblab: get_all_flags failed: %s", e)
+        return {}

--- a/src/clsplusplus/weblab_watcher.py
+++ b/src/clsplusplus/weblab_watcher.py
@@ -1,0 +1,158 @@
+"""Weblab auto-rollback watcher.
+
+Polls the ops-health rolling window. When a watched weblab's success metrics
+breach the configured thresholds, it disables the PostHog flag — every user
+falls back to control — and records the verdict for the /admin/weblab page.
+
+Modeled on SubscriptionWatchdog: a background asyncio task with start/stop,
+plus run_once()/evaluate() for on-demand use by the admin endpoint.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+import httpx
+
+from clsplusplus.config import Settings
+from clsplusplus.health_metrics import aggregate_health
+
+logger = logging.getLogger(__name__)
+
+_STARTUP_DELAY_SECONDS = 60
+
+
+class WeblabWatcher:
+    def __init__(self, settings: Settings):
+        self.settings = settings
+        self._task: Optional[asyncio.Task] = None
+        # Last verdict — surfaced read-only by GET /admin/weblab.
+        self.last_result: dict = {"status": "pending"}
+
+    # ── lifecycle ─────────────────────────────────────────────────────────
+    def start(self) -> None:
+        if self._task is not None and not self._task.done():
+            return
+        self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        if self._task is None:
+            return
+        self._task.cancel()
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
+        self._task = None
+
+    def _watched_flags(self) -> list[str]:
+        raw = self.settings.weblab_watched_flags or ""
+        return [f.strip() for f in raw.split(",") if f.strip()]
+
+    # ── evaluation ────────────────────────────────────────────────────────
+    async def evaluate(self) -> dict:
+        """Read ops-health and return a green/red verdict. No side effects."""
+        s = self.settings
+        try:
+            health = await aggregate_health(
+                s.redis_url, window_minutes=s.weblab_health_window_minutes
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning("weblab watcher: health read failed: %s", e)
+            return {"status": "unknown", "error": str(e),
+                    "watched_flags": self._watched_flags()}
+
+        total = int(health.get("total_requests", 0) or 0)
+        err_5xx = float(health.get("error_rate_5xx", 0.0) or 0.0)
+        p95 = float((health.get("latency_ms") or {}).get("p95", 0.0) or 0.0)
+
+        breaches: list[str] = []
+        # Below the minimum sample we cannot trust the rate — stay green.
+        if total >= s.weblab_rollback_min_requests:
+            if err_5xx > s.weblab_rollback_5xx_pct:
+                breaches.append(
+                    f"5xx error rate {err_5xx:.2f}% > {s.weblab_rollback_5xx_pct}%"
+                )
+            if p95 > s.weblab_rollback_p95_ms:
+                breaches.append(
+                    f"p95 latency {p95:.0f}ms > {s.weblab_rollback_p95_ms}ms"
+                )
+
+        return {
+            "status": "red" if breaches else "green",
+            "breaches": breaches,
+            "metrics": {
+                "total_requests": total,
+                "error_rate_5xx": round(err_5xx, 3),
+                "p95_ms": round(p95, 1),
+            },
+            "watched_flags": self._watched_flags(),
+            "auto_rollback_enabled": s.weblab_auto_rollback_enabled,
+        }
+
+    async def run_once(self) -> dict:
+        """Evaluate and, when red, roll back every watched flag."""
+        result = await self.evaluate()
+        result["rolled_back"] = []
+        if result.get("status") == "red" and self.settings.weblab_auto_rollback_enabled:
+            for flag in result.get("watched_flags", []):
+                if await self._rollback(flag, result["breaches"]):
+                    result["rolled_back"].append(flag)
+        self.last_result = result
+        return result
+
+    async def _run(self) -> None:
+        await asyncio.sleep(_STARTUP_DELAY_SECONDS)  # let the pool warm up
+        while True:
+            try:
+                result = await self.run_once()
+                if result.get("rolled_back"):
+                    logger.error(
+                        "weblab watcher: ROLLED BACK %s — breaches: %s",
+                        result["rolled_back"], result.get("breaches"),
+                    )
+            except Exception as e:  # noqa: BLE001
+                logger.warning("weblab watcher: tick failed: %s", e)
+            await asyncio.sleep(self.settings.weblab_metric_poll_seconds)
+
+    # ── rollback ──────────────────────────────────────────────────────────
+    async def _rollback(self, flag_key: str, breaches: list) -> bool:
+        """Disable a PostHog flag via the management API. Returns success."""
+        s = self.settings
+        if not (s.posthog_personal_api_key and s.posthog_project_id):
+            logger.error(
+                "weblab watcher: cannot roll back %s — PostHog management "
+                "API not configured (need CLS_POSTHOG_PERSONAL_API_KEY + "
+                "CLS_POSTHOG_PROJECT_ID)", flag_key,
+            )
+            return False
+        headers = {"Authorization": f"Bearer {s.posthog_personal_api_key}"}
+        base = (f"{s.posthog_api_host.rstrip('/')}"
+                f"/api/projects/{s.posthog_project_id}/feature_flags")
+        try:
+            async with httpx.AsyncClient(timeout=15.0) as client:
+                resp = await client.get(base + "/", headers=headers,
+                                        params={"limit": 300})
+                resp.raise_for_status()
+                flag_id = next(
+                    (f.get("id") for f in resp.json().get("results", [])
+                     if f.get("key") == flag_key),
+                    None,
+                )
+                if flag_id is None:
+                    logger.error("weblab watcher: flag %s not found in PostHog",
+                                 flag_key)
+                    return False
+                patch = await client.patch(
+                    f"{base}/{flag_id}/", headers=headers,
+                    json={"active": False},
+                )
+                patch.raise_for_status()
+            logger.error("weblab watcher: disabled PostHog flag %s — %s",
+                         flag_key, breaches)
+            return True
+        except Exception as e:  # noqa: BLE001
+            logger.error("weblab watcher: rollback of %s failed: %s",
+                         flag_key, e)
+            return False

--- a/tests/functional/test_routes_blackbox.py
+++ b/tests/functional/test_routes_blackbox.py
@@ -77,7 +77,6 @@ ADMIN_ROUTES: list[tuple[str, str, tuple[int, ...]]] = [
     ("GET",  "/admin/metrics/extension",            (200, 401, 403)),
     ("GET",  "/admin/metrics/storage",              (200, 401, 403)),
     ("GET",  "/admin/metrics/overview",             (200, 401, 403)),
-    ("GET",  "/admin/metrics/dashboard",            (200, 401, 403)),
     ("GET",  "/admin/rbac/scopes",                  (200, 401, 403)),
     ("GET",  "/admin/rbac/roles",                   (200, 401, 403)),
     ("GET",  "/admin/rbac/groups",                  (200, 401, 403)),

--- a/tests/functional/test_routes_blackbox.py
+++ b/tests/functional/test_routes_blackbox.py
@@ -76,6 +76,8 @@ ADMIN_ROUTES: list[tuple[str, str, tuple[int, ...]]] = [
     ("GET",  "/admin/metrics/users",                (200, 401, 403)),
     ("GET",  "/admin/metrics/extension",            (200, 401, 403)),
     ("GET",  "/admin/metrics/storage",              (200, 401, 403)),
+    ("GET",  "/admin/metrics/overview",             (200, 401, 403)),
+    ("GET",  "/admin/metrics/dashboard",            (200, 401, 403)),
     ("GET",  "/admin/rbac/scopes",                  (200, 401, 403)),
     ("GET",  "/admin/rbac/roles",                   (200, 401, 403)),
     ("GET",  "/admin/rbac/groups",                  (200, 401, 403)),

--- a/tests/test_weblab.py
+++ b/tests/test_weblab.py
@@ -1,0 +1,201 @@
+"""Tests for the PostHog-backed weblab rollout system.
+
+Covers the weblab helpers (fail-safe behaviour), the auto-rollback watcher's
+green/red evaluation + rollback gating, and the launch-rollout gate on the
+registration endpoint.
+"""
+from __future__ import annotations
+
+import pytest
+
+from clsplusplus import weblab, weblab_watcher
+from clsplusplus.config import Settings
+
+pytestmark = [pytest.mark.unit, pytest.mark.regression]
+
+
+# ── weblab helpers ────────────────────────────────────────────────────────
+
+class _FakeClient:
+    """Stand-in PostHog client."""
+
+    def __init__(self, flag_value):
+        self._v = flag_value
+
+    def feature_enabled(self, flag, distinct_id):
+        return bool(self._v)
+
+    def get_feature_flag(self, flag, distinct_id):
+        return self._v
+
+    def get_all_flags(self, distinct_id):
+        return {"launch-rollout": self._v}
+
+
+class TestWeblabHelpers:
+    def setup_method(self):
+        weblab.reset_client()
+
+    def teardown_method(self):
+        weblab.reset_client()
+
+    def test_enabled_fails_safe_to_default_when_unconfigured(self):
+        # No posthog_api_key → no client → caller default is returned.
+        s = Settings(posthog_api_key="")
+        assert weblab.enabled("launch-rollout", "user@x.com", s, default=True) is True
+        assert weblab.enabled("launch-rollout", "user@x.com", s, default=False) is False
+
+    def test_treatment_fails_safe_to_default_when_unconfigured(self):
+        s = Settings(posthog_api_key="")
+        assert weblab.treatment("feat", "ns-1", s, default="control") == "control"
+
+    def test_enabled_reads_from_client(self):
+        weblab._client = _FakeClient(True)
+        s = Settings(posthog_api_key="phc_test")
+        assert weblab.enabled("launch-rollout", "user@x.com", s) is True
+
+    def test_treatment_maps_variant_and_bool(self):
+        s = Settings(posthog_api_key="phc_test")
+        weblab._client = _FakeClient("T2")
+        assert weblab.treatment("feat", "ns-1", s) == "T2"
+        weblab._client = _FakeClient(True)
+        assert weblab.treatment("feat", "ns-1", s) == "T1"
+        weblab._client = _FakeClient(None)
+        assert weblab.treatment("feat", "ns-1", s, default="control") == "control"
+
+    def test_helpers_swallow_client_errors(self):
+        class _Boom:
+            def feature_enabled(self, *a):
+                raise RuntimeError("posthog down")
+
+        weblab._client = _Boom()
+        s = Settings(posthog_api_key="phc_test")
+        # Must not raise — falls back to default.
+        assert weblab.enabled("launch-rollout", "u", s, default=True) is True
+
+
+# ── auto-rollback watcher ─────────────────────────────────────────────────
+
+def _health(total=1000, err_5xx=0.0, p95=200.0):
+    return {
+        "total_requests": total,
+        "error_rate_5xx": err_5xx,
+        "latency_ms": {"p95": p95},
+    }
+
+
+class TestWeblabWatcher:
+    async def test_evaluate_green_when_healthy(self, monkeypatch):
+        async def fake(url, window_minutes=60):
+            return _health(total=1000, err_5xx=0.1, p95=200)
+
+        monkeypatch.setattr(weblab_watcher, "aggregate_health", fake)
+        w = weblab_watcher.WeblabWatcher(Settings())
+        v = await w.evaluate()
+        assert v["status"] == "green"
+        assert v["breaches"] == []
+
+    async def test_evaluate_red_on_high_5xx(self, monkeypatch):
+        async def fake(url, window_minutes=60):
+            return _health(total=1000, err_5xx=9.0, p95=200)
+
+        monkeypatch.setattr(weblab_watcher, "aggregate_health", fake)
+        w = weblab_watcher.WeblabWatcher(Settings())
+        v = await w.evaluate()
+        assert v["status"] == "red"
+        assert any("5xx" in b for b in v["breaches"])
+
+    async def test_evaluate_red_on_high_latency(self, monkeypatch):
+        async def fake(url, window_minutes=60):
+            return _health(total=1000, err_5xx=0.0, p95=9000)
+
+        monkeypatch.setattr(weblab_watcher, "aggregate_health", fake)
+        w = weblab_watcher.WeblabWatcher(Settings())
+        v = await w.evaluate()
+        assert v["status"] == "red"
+        assert any("p95" in b for b in v["breaches"])
+
+    async def test_evaluate_green_below_min_requests(self, monkeypatch):
+        # Bad rates but a tiny sample — must not trip.
+        async def fake(url, window_minutes=60):
+            return _health(total=3, err_5xx=80.0, p95=9000)
+
+        monkeypatch.setattr(weblab_watcher, "aggregate_health", fake)
+        w = weblab_watcher.WeblabWatcher(Settings())
+        v = await w.evaluate()
+        assert v["status"] == "green"
+
+    async def test_run_once_rolls_back_when_red_and_enabled(self, monkeypatch):
+        async def fake(url, window_minutes=60):
+            return _health(total=1000, err_5xx=9.0, p95=200)
+
+        monkeypatch.setattr(weblab_watcher, "aggregate_health", fake)
+        w = weblab_watcher.WeblabWatcher(
+            Settings(weblab_auto_rollback_enabled=True,
+                     weblab_watched_flags="launch-rollout")
+        )
+        called = []
+
+        async def fake_rollback(flag, breaches):
+            called.append(flag)
+            return True
+
+        monkeypatch.setattr(w, "_rollback", fake_rollback)
+        result = await w.run_once()
+        assert result["status"] == "red"
+        assert result["rolled_back"] == ["launch-rollout"]
+        assert called == ["launch-rollout"]
+
+    async def test_run_once_no_rollback_when_disabled(self, monkeypatch):
+        async def fake(url, window_minutes=60):
+            return _health(total=1000, err_5xx=9.0, p95=200)
+
+        monkeypatch.setattr(weblab_watcher, "aggregate_health", fake)
+        w = weblab_watcher.WeblabWatcher(
+            Settings(weblab_auto_rollback_enabled=False)
+        )
+        result = await w.run_once()
+        assert result["status"] == "red"
+        assert result["rolled_back"] == []
+
+    async def test_run_once_no_rollback_when_green(self, monkeypatch):
+        async def fake(url, window_minutes=60):
+            return _health(total=1000, err_5xx=0.0, p95=100)
+
+        monkeypatch.setattr(weblab_watcher, "aggregate_health", fake)
+        w = weblab_watcher.WeblabWatcher(
+            Settings(weblab_auto_rollback_enabled=True)
+        )
+        result = await w.run_once()
+        assert result["status"] == "green"
+        assert result["rolled_back"] == []
+
+
+# ── launch-rollout gate on /v1/auth/register ──────────────────────────────
+
+class TestLaunchRolloutGate:
+    async def test_signup_gated_to_waitlist_when_not_rolled_in(
+        self, client, monkeypatch
+    ):
+        monkeypatch.setattr(weblab, "enabled", lambda *a, **k: False)
+        r = await client.post(
+            "/v1/auth/register",
+            json={"email": "wave@acme.com", "password": "supersecret123",
+                  "name": "Wave User"},
+        )
+        assert r.status_code == 503
+        body = r.json()
+        assert body.get("error") == "launch_wave"
+        assert body.get("waitlist") is True
+
+    async def test_signup_passes_gate_when_rolled_in(self, client, monkeypatch):
+        monkeypatch.setattr(weblab, "enabled", lambda *a, **k: True)
+        r = await client.post(
+            "/v1/auth/register",
+            json={"email": "rolled@acme.com", "password": "supersecret123",
+                  "name": "Rolled User"},
+        )
+        # Rolled in → past the weblab gate. Downstream may 200 or fail on cap
+        # or email, but it must NOT be the launch_wave rejection.
+        assert not (r.status_code == 503
+                    and r.json().get("error") == "launch_wave")


### PR DESCRIPTION
## Summary
Adds an internal "Weblab" rollout system (Amazon Weblab-style) on top of PostHog feature flags — no new infrastructure, since PostHog is already integrated.

- **`weblab.py`** — `enabled()` / `treatment()` / `all_flags()` over the PostHog SDK; every call fails safe to a default.
- **launch-rollout weblab** — a flag check in `/v1/auth/register` is the % dial for active account vs waitlist. Fails open; `max_active_users` stays the hard ceiling.
- **`weblab_watcher.py`** — background loop; auto-disables a flag via the PostHog management API when 5xx >2% or p95 >3s (opt-in via `CLS_WEBLAB_AUTO_ROLLBACK_ENABLED`).
- **`GET /v1/config/flags`** — evaluated flags for the caller; the extension caches them to branch on a treatment without a redeploy.
- **`GET /admin/weblab`** — control status: watched flags + latest green/red verdict.

The PostHog UI is the dial-up control surface.

## Operator setup before launch
- Create the `launch-rollout` flag (and any feature flag) in PostHog.
- Set `CLS_POSTHOG_API_KEY`, `CLS_POSTHOG_PERSONAL_API_KEY`, `CLS_POSTHOG_PROJECT_ID`; set `CLS_WEBLAB_AUTO_ROLLBACK_ENABLED=true` to arm auto-rollback.

## Test plan
- [ ] CI unit job green (incl. `tests/test_weblab.py` — 14 tests)
- [ ] CI integration job green (registration gate)
- [ ] CI extension-lint green

🤖 Generated with [Claude Code](https://claude.com/claude-code)