### PR TITLE
CX audit fixes: #436-#440

### DIFF
--- a/.github/workflows/keepwarm.yml
+++ b/.github/workflows/keepwarm.yml
@@ -1,0 +1,23 @@
+name: Keep warm
+
+# Render's free tier sleeps after ~15 min idle, and the first request after
+# pays a cold-start penalty (~1s time-to-first-byte was measured on the
+# landing page). A ping every 10 minutes keeps the API and the site warm so
+# real visitors never hit a cold start.
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping API + landing page
+        run: |
+          curl -sS -m 25 -o /dev/null \
+            -w "api   %{http_code}  %{time_total}s\n" \
+            https://www.clsplusplus.com/api/v1/health || true
+          curl -sS -m 25 -o /dev/null \
+            -w "site  %{http_code}  %{time_total}s\n" \
+            https://www.clsplusplus.com/ || true

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -62,6 +62,22 @@ echo "cls_live_$(openssl rand -hex 24)"
 
 ---
 
+## Namespaces
+
+A **namespace** is a logical partition of memories — a string you choose. Pass
+it as the `namespace` field on every memory call (`write`, `read`, `forget`).
+Memories in one namespace are fully isolated from those in another.
+
+- The **API key authorizes** the request; the **namespace scopes** it.
+- One API key (your application) can use **many namespaces**. The usual
+  pattern is **one namespace per end-user** of your app, e.g.
+  `namespace: "user-42"`.
+- Omit it and memories land in the `"default"` namespace.
+- In the SDK, the `Brain("alice")` constructor argument *is* the namespace —
+  every call that `Brain` makes is scoped to `"alice"`.
+
+---
+
 ## API Endpoints
 
 | Method | Path | Description |

--- a/sdk-js/README.md
+++ b/sdk-js/README.md
@@ -53,6 +53,21 @@ const brain = new Brain("alice", {
 });
 ```
 
+## Namespaces
+
+The first argument to `new Brain(...)` is a **namespace** — a logical
+partition you choose. Memories in one namespace are fully isolated from
+another:
+
+```ts
+const alice = new Brain("alice");
+const bob = new Brain("bob"); // completely separate memories
+```
+
+Your API key authorizes the request; the namespace scopes it. One key can
+use many namespaces — the usual pattern is **one namespace per end-user** of
+your app (e.g. their user id).
+
 ## Full API
 
 | Method | Description |

--- a/src/clsplusplus/api.py
+++ b/src/clsplusplus/api.py
@@ -51,6 +51,48 @@ from clsplusplus.models import _validate_namespace as validate_namespace
 from clsplusplus.sleep_cycle import SleepOrchestrator
 
 
+async def _file_github_bug_issue(settings, *, comment, context, score, user_email):
+    """Best-effort: file a customer bug report into the central GitHub tracker.
+
+    Customer-reported bugs are prod-cx — they go straight to GitHub Issues,
+    labeled and prioritised. Never raises: a tracker hiccup must not fail the
+    feedback write. No-op when no token is configured.
+    """
+    token = getattr(settings, "github_issue_token", "")
+    if not token:
+        return
+    repo = getattr(settings, "github_issue_repo", "")
+    summary = (comment or "Customer bug report").strip().splitlines()[0][:80]
+    body = (
+        "Customer-reported via the in-app feedback widget.\n\n"
+        f"- **Rating:** {score}/5\n"
+        f"- **Where:** {context or '—'}\n"
+        f"- **Reporter:** {user_email or 'unknown'}\n\n"
+        "---\n\n"
+        f"{comment or '(no description provided)'}"
+    )
+    try:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(
+                f"https://api.github.com/repos/{repo}/issues",
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Accept": "application/vnd.github+json",
+                },
+                json={
+                    "title": f"[prod-cx] {summary}",
+                    "body": body,
+                    "labels": ["bug", "prod-cx", "source:user", "priority:P1"],
+                },
+            )
+            resp.raise_for_status()
+    except Exception as e:  # noqa: BLE001
+        logging.getLogger(__name__).warning(
+            "feedback: GitHub issue creation failed: %s", e)
+
+
 def create_app(settings: Optional[Settings] = None) -> FastAPI:
     """Create FastAPI application."""
     settings = settings or Settings()
@@ -2283,6 +2325,17 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
                 await record_signal(user_id, "thumbs_down", settings)
             except Exception:
                 pass
+
+        # A customer bug report is a prod-cx ticket — file it into the central
+        # GitHub tracker. Best-effort; never fails the feedback write.
+        if context and context.lower().startswith("bug"):
+            await _file_github_bug_issue(
+                settings,
+                comment=comment,
+                context=context,
+                score=score,
+                user_email=getattr(request.state, "user_email", None),
+            )
 
         return {"status": "ok", "id": row["id"]}
 

--- a/src/clsplusplus/config.py
+++ b/src/clsplusplus/config.py
@@ -282,6 +282,11 @@ class Settings(BaseSettings):
     # Sentry project URL — the "Errors" deep-link on the admin metrics page.
     sentry_url: str = "https://sentry.io"     # CLS_SENTRY_URL
 
+    # Customer bug reports from the feedback widget are filed into the central
+    # GitHub tracker when a token is set. Empty token = feature disabled.
+    github_issue_token: str = ""                          # CLS_GITHUB_ISSUE_TOKEN
+    github_issue_repo: str = "rajamohan1950/CLSplusplus"   # CLS_GITHUB_ISSUE_REPO
+
     # Demo LLM keys (optional; demo uses these for real Claude/OpenAI/Gemini)
     anthropic_api_key: Optional[str] = None
     openai_api_key: Optional[str] = None

--- a/tests/test_feedback_github.py
+++ b/tests/test_feedback_github.py
@@ -1,0 +1,90 @@
+"""Tests for filing customer bug reports into the central GitHub tracker."""
+from __future__ import annotations
+
+import pytest
+
+from clsplusplus.api import _file_github_bug_issue
+from clsplusplus.config import Settings
+
+pytestmark = [pytest.mark.unit, pytest.mark.regression]
+
+
+async def test_noop_without_token():
+    # No token configured → must not raise and must not call out.
+    await _file_github_bug_issue(
+        Settings(github_issue_token=""),
+        comment="login broke",
+        context="bug · /signup",
+        score=2,
+        user_email="a@b.com",
+    )
+
+
+async def test_files_labeled_issue(monkeypatch):
+    captured: dict = {}
+
+    class _Resp:
+        def raise_for_status(self):
+            pass
+
+    class _Client:
+        def __init__(self, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, url, headers=None, json=None):
+            captured["url"] = url
+            captured["json"] = json
+            return _Resp()
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _Client)
+
+    await _file_github_bug_issue(
+        Settings(github_issue_token="ghp_test", github_issue_repo="acme/repo"),
+        comment="login button does nothing",
+        context="bug · /signup",
+        score=2,
+        user_email="dev@acme.com",
+    )
+
+    assert captured["url"] == "https://api.github.com/repos/acme/repo/issues"
+    assert captured["json"]["title"].startswith("[prod-cx]")
+    assert set(captured["json"]["labels"]) == {
+        "bug", "prod-cx", "source:user", "priority:P1",
+    }
+    assert "dev@acme.com" in captured["json"]["body"]
+    assert "2/5" in captured["json"]["body"]
+
+
+async def test_swallows_errors(monkeypatch):
+    class _Client:
+        def __init__(self, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, *a, **k):
+            raise RuntimeError("github down")
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _Client)
+    # Best-effort — a tracker failure must not raise.
+    await _file_github_bug_issue(
+        Settings(github_issue_token="ghp_test"),
+        comment="x",
+        context="bug · /p",
+        score=1,
+        user_email="a@b.com",
+    )


### PR DESCRIPTION
## Summary
Resolves the five CX-audit issues from the end-user journey review.

- **#436** — landing quickstart snippet corrected (`@cls-memory/sdk`/`CLSMemory` → real `clsplusplus`/`Brain`); keep-warm workflow added so Render cold start stops bleeding ~1s TTFB into the first visitor.
- **#437** — namespace semantics documented in `docs/API_DOCUMENTATION.md` + the JS SDK README.
- **#438** — `/admin/feedback` CSAT dashboard tab (v0-cls-memory-website).
- **#439** — customer bug reports file a GitHub issue (`bug` + `prod-cx` + `source:user` + `priority:P1`); gated on `CLS_GITHUB_ISSUE_TOKEN`, best-effort.
- **#440** — orphaned feedback-provider removed.

Frontend changes (#438, #440, landing snippet) shipped via the separate `v0-cls-memory-website` repo. This PR carries the API + docs + workflow changes.

## Test plan
- [ ] CI unit job green (incl. `tests/test_feedback_github.py`)
- [ ] CI integration + extension-lint green

Closes #436 #437 #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)